### PR TITLE
Log where URLs are hosted - cc_critical option added

### DIFF
--- a/bin/packages/config.cfg.sample
+++ b/bin/packages/config.cfg.sample
@@ -61,6 +61,8 @@ adress = tcp://127.0.0.1:5003
 [PubSub_Url]
 adress = tcp://127.0.0.1:5004
 channel = urls
+# country code logged as critical
+cc_critical = DE
 
 # Indexer configuration
 [Indexer]


### PR DESCRIPTION
It logs where the hostname of the URL is hosted (ASN and geographic location).
A simple option cc_critical added to set the country code to log as critical.
