### PR TITLE
Handling of multiple feeders

### DIFF
--- a/bin/Global.py
+++ b/bin/Global.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
             if int(time.time() - time_1) > 30:
                 to_print = 'Global; ; ; ;glob Processed {0} paste(s)'.format(processed_paste)
                 print to_print
-                publisher.info(to_print)
+                #publisher.info(to_print)
                 time_1 = time.time()
                 processed_paste = 0
             time.sleep(1)
@@ -72,8 +72,6 @@ if __name__ == '__main__':
             os.makedirs(dirname)
 
         with open(filename, 'wb') as f:
-            print gzip64encoded
-            print base64.standard_b64decode(gzip64encoded)
             f.write(base64.standard_b64decode(gzip64encoded))
         p.populate_set_out(filename)
         processed_paste+=1

--- a/bin/Global.py
+++ b/bin/Global.py
@@ -72,6 +72,8 @@ if __name__ == '__main__':
             os.makedirs(dirname)
 
         with open(filename, 'wb') as f:
+            print gzip64encoded
+            print base64.standard_b64decode(gzip64encoded)
             f.write(base64.standard_b64decode(gzip64encoded))
         p.populate_set_out(filename)
         processed_paste+=1

--- a/bin/Helper.py
+++ b/bin/Helper.py
@@ -98,6 +98,7 @@ class PubSub(object):
                         msg = sub.recv(zmq.NOBLOCK)
                         yield msg.split(' ', 1)[1]
                     except zmq.error.Again as e:
+                        time.sleep(0.2)
                         pass
         else:
             raise Exception('No subscribe function defined')

--- a/bin/LAUNCH.sh
+++ b/bin/LAUNCH.sh
@@ -114,6 +114,8 @@ function launching_scripts {
 
     screen -S "Script" -X screen -t "ModuleInformation" bash -c './ModuleInformation.py -k 0 -c 1; read x'
     sleep 0.1
+    screen -S "Script" -X screen -t "Mixer" bash -c './Mixer.py; read x'
+    sleep 0.1
     screen -S "Script" -X screen -t "Global" bash -c './Global.py; read x'
     sleep 0.1
     screen -S "Script" -X screen -t "Duplicates" bash -c './Duplicates.py; read x'

--- a/bin/Mixer.py
+++ b/bin/Mixer.py
@@ -150,6 +150,7 @@ if __name__ == '__main__':
         else:
             print "Empty Queues: Waiting..."
             if int(time.time() - time_1) > refresh_time:
+                print processed_paste_per_feeder
                 to_print = 'Mixer; ; ; ;mixer_all All_feeders Processed {0} paste(s) in {1}sec'.format(processed_paste, refresh_time)
                 print to_print
                 publisher.info(to_print)

--- a/bin/Mixer.py
+++ b/bin/Mixer.py
@@ -150,7 +150,7 @@ if __name__ == '__main__':
         else:
             print "Empty Queues: Waiting..."
             if int(time.time() - time_1) > refresh_time:
-                to_print = 'Mixer; ; ; ;mixer_all Processed {0} paste(s) in {1}sec'.format(processed_paste, refresh_time)
+                to_print = 'Mixer; ; ; ;mixer_all All_feeders Processed {0} paste(s) in {1}sec'.format(processed_paste, refresh_time)
                 print to_print
                 publisher.info(to_print)
                 processed_paste = 0

--- a/bin/Mixer.py
+++ b/bin/Mixer.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+# -*-coding:UTF-8 -*
+"""
+The ZMQ_Feed_Q Module
+=====================
+
+This module is consuming the Redis-list created by the ZMQ_Feed_Q Module.
+
+This module take all the feeds provided in the config.
+Depending on the configuration, this module will process the feed as follow:
+    operation_mode 1: "Avoid any duplicate from any sources"
+        - The module maintain a list of content for each paste
+            - If the content is new, process it
+            - Else, do not process it but keep track for statistics on duplicate
+
+    operation_mode 2: "Keep duplicate coming from different sources"
+        - The module maintain a list of name given to the paste by the feeder
+            - If the name has not yet been seen, process it
+            - Elseif, the saved content associated with the paste is not the same, process it
+            - Else, do not process it but keep track for statistics on duplicate
+
+Note that the hash of the content is defined as the gzip64encoded
+
+Requirements
+------------
+
+*Need running Redis instances.
+*Need the ZMQ_Feed_Q Module running to be able to work properly.
+
+"""
+import base64
+import os
+import time
+from pubsublogger import publisher
+import redis
+import ConfigParser
+
+from Helper import Process
+
+
+# CONFIG #
+refresh_time = 30
+
+
+
+if __name__ == '__main__':
+    publisher.port = 6380
+    publisher.channel = 'Script'
+
+    config_section = 'Mixer'
+
+    p = Process(config_section)
+
+    configfile = os.path.join(os.environ['AIL_BIN'], 'packages/config.cfg')
+    if not os.path.exists(configfile):
+        raise Exception('Unable to find the configuration file. \
+                        Did you set environment variables? \
+                        Or activate the virtualenv.')
+
+    cfg = ConfigParser.ConfigParser()
+    cfg.read(configfile)
+
+    # REDIS #
+    server = redis.StrictRedis(
+        host=cfg.get("Redis_Mixer", "host"),
+        port=cfg.getint("Redis_Mixer", "port"),
+        db=cfg.getint("Redis_Mixer", "db"))
+
+    # LOGGING #
+    publisher.info("Feed Script started to receive & publish.")
+
+    # OTHER CONFIG #
+    operation_mode = cfg.getint("Module_Mixer", "operation_mode")
+    ttl_key = cfg.getint("Module_Mixer", "ttl_duplicate")
+
+    # STATS #
+    processed_paste = 0
+    processed_paste_per_feeder = {}
+    duplicated_paste_per_feeder = {}
+    time_1 = time.time()
+
+
+    while True:
+
+        message = p.get_from_set()
+        if message is not None:
+            splitted = message.split()
+            if len(splitted) == 2:
+                paste, gzip64encoded = splitted
+                try:
+                    feeder_name, paste_name = paste.split('>')
+                    feeder_name.replace(" ","")
+                except ValueError as e:
+                    feeder_name = "unnamed_feeder"
+                    paste_name = paste
+
+                # Processed paste
+                processed_paste += 1
+                try:
+                    processed_paste_per_feeder[feeder_name] += 1
+                except KeyError as e:
+                    # new feeder
+                    processed_paste_per_feeder[feeder_name] = 1
+                    duplicated_paste_per_feeder[feeder_name] = 0
+
+                relay_message = "{0} {1}".format(paste_name, gzip64encoded)
+
+                # Avoid any duplicate coming from any sources
+                if operation_mode == 1:
+                    if server.exists(gzip64encoded): # Content already exists
+                        #STATS
+                        duplicated_paste_per_feeder[feeder_name] += 1
+                    else: # New content
+                        p.populate_set_out(relay_message)
+                    server.sadd(gzip64encoded, feeder_name)
+                    server.expire(gzip64encoded, ttl_key)
+
+
+                # Keep duplicate coming from different sources
+                else:
+                    # Filter to avoid duplicate 
+                    content = server.get('HASH_'+paste_name)
+                    if content is None:
+                        # New content
+                        # Store in redis for filtering
+                        server.set('HASH_'+paste_name, content)
+                        server.sadd(paste_name, feeder_name)
+                        server.expire(paste_name, ttl_key)
+                        server.expire('HASH_'+paste_name, ttl_key)
+                        p.populate_set_out(relay_message)
+                    else:
+                        if gzip64encoded != content:
+                            # Same paste name but different content
+                            #STATS
+                            duplicated_paste_per_feeder[feeder_name] += 1
+                            server.sadd(paste_name, feeder_name)
+                            server.expire(paste_name, ttl_key)
+                            p.populate_set_out(relay_message)
+                        else:
+                            # Already processed
+                            # Keep track of processed pastes
+                            #STATS
+                            duplicated_paste_per_feeder[feeder_name] += 1
+                            continue
+
+            else:
+                # TODO Store the name of the empty paste inside a Redis-list.
+                print "Empty Paste: not processed"
+                publisher.debug("Empty Paste: {0} not processed".format(message))
+        else:
+            print "Empty Queues: Waiting..."
+            if int(time.time() - time_1) > refresh_time:
+                to_print = 'Mixer; ; ; ;mixer_all Processed {0} paste(s) in {1}sec'.format(processed_paste, refresh_time)
+                print to_print
+                publisher.info(to_print)
+                processed_paste = 0
+
+                for feeder, count in processed_paste_per_feeder.iteritems():
+                    to_print = 'Mixer; ; ; ;mixer_{0} {0} Processed {1} paste(s) in {2}sec'.format(feeder, count, refresh_time)
+                    print to_print
+                    publisher.info(to_print)
+                    processed_paste_per_feeder[feeder] = 0
+
+                for feeder, count in duplicated_paste_per_feeder.iteritems():
+                    to_print = 'Mixer; ; ; ;mixer_{0} {0} Duplicated {1} paste(s) in {2}sec'.format(feeder, count, refresh_time)
+                    print to_print
+                    publisher.info(to_print)
+                    duplicated_paste_per_feeder[feeder] = 0
+
+                time_1 = time.time()
+            time.sleep(0.5)
+            continue

--- a/bin/Mixer.py
+++ b/bin/Mixer.py
@@ -112,6 +112,7 @@ if __name__ == '__main__':
                         duplicated_paste_per_feeder[feeder_name] += 1
                     else: # New content
                         p.populate_set_out(relay_message)
+                        # OR populate another set based on the feeder_name
                     server.sadd(gzip64encoded, feeder_name)
                     server.expire(gzip64encoded, ttl_key)
 
@@ -128,6 +129,7 @@ if __name__ == '__main__':
                         server.expire(paste_name, ttl_key)
                         server.expire('HASH_'+paste_name, ttl_key)
                         p.populate_set_out(relay_message)
+                        # OR populate another set based on the feeder_name
                     else:
                         if gzip64encoded != content:
                             # Same paste name but different content
@@ -136,6 +138,7 @@ if __name__ == '__main__':
                             server.sadd(paste_name, feeder_name)
                             server.expire(paste_name, ttl_key)
                             p.populate_set_out(relay_message)
+                            # OR populate another set based on the feeder_name
                         else:
                             # Already processed
                             # Keep track of processed pastes

--- a/bin/ModuleInformation.py
+++ b/bin/ModuleInformation.py
@@ -25,9 +25,9 @@ import json
 from terminaltables import AsciiTable
 import textwrap
 from colorama import Fore, Back, Style, init
+import curses
 
 # CONFIG VARIABLES
-threshold_stucked_module = 60*10*1 #1 hour
 kill_retry_threshold = 60 #1m
 log_filename = "../logs/moduleInfo.log"
 command_search_pid = "ps a -o pid,cmd | grep {}"
@@ -38,6 +38,15 @@ init() #Necesary for colorama
 printarrayGlob = [None]*14
 printarrayGlob.insert(0, ["Time", "Module", "PID", "Action"])
 lastTimeKillCommand = {}
+
+#Curses init
+#stdscr = curses.initscr()
+#curses.cbreak()
+#stdscr.keypad(1)
+
+# GLOBAL
+last_refresh = 0
+
 
 def getPid(module):
     p = Popen([command_search_pid.format(module+".py")], stdin=PIPE, stdout=PIPE, bufsize=1, shell=True)
@@ -145,23 +154,33 @@ def get_color(time, idle):
         temp = time.split(':')
         time = int(temp[0])*3600 + int(temp[1])*60 + int(temp[2])
 
-        if time >= threshold_stucked_module:
+        if time >= args.treshold:
             if not idle:
                 return Back.RED + Style.BRIGHT
             else:
                 return Back.MAGENTA + Style.BRIGHT
-        elif time > threshold_stucked_module/2:
+        elif time > args.treshold/2:
             return Back.YELLOW + Style.BRIGHT
         else:
             return Back.GREEN + Style.BRIGHT
     else:
         return Style.RESET_ALL
 
+def waiting_refresh():
+    global last_refresh
+    if time.time() - last_refresh < args.refresh:
+        return False
+    else:
+        last_refresh = time.time()
+        return True
+
+    
 
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description='Show info concerning running modules and log suspected stucked modules. May be use to automatically kill and restart stucked one.')
     parser.add_argument('-r', '--refresh', type=int, required=False, default=1, help='Refresh rate')
+    parser.add_argument('-t', '--treshold', type=int, required=False, default=60*10*1, help='Refresh rate')
     parser.add_argument('-k', '--autokill', type=int, required=False, default=0, help='Enable auto kill option (1 for TRUE, anything else for FALSE)')
     parser.add_argument('-c', '--clear', type=int, required=False, default=0, help='Clear the current module information (Used to clear data from old launched modules)')
 
@@ -175,8 +194,6 @@ if __name__ == "__main__":
 
     cfg = ConfigParser.ConfigParser()
     cfg.read(configfile)
-
-    threshold_stucked_module = cfg.getint("Module_ModuleInformation", "threshold_stucked_module")
 
     # REDIS #
     server = redis.StrictRedis(
@@ -199,123 +216,138 @@ if __name__ == "__main__":
         cleanRedis()
 
         while True:
+            if waiting_refresh():
 
-            all_queue = set()
-            printarray1 = []
-            printarray2 = []
-            printarray3 = []
-            for queue, card in server.hgetall("queues").iteritems():
-                all_queue.add(queue)
-                key = "MODULE_" + queue + "_"
-                keySet = "MODULE_TYPE_" + queue
-                array_module_type = []
-
-                for moduleNum in server.smembers(keySet):
-                    value = server.get(key + str(moduleNum))
-                    if value is not None:
-                        timestamp, path = value.split(", ")
-                        if timestamp is not None and path is not None:
-                            startTime_readable = datetime.datetime.fromtimestamp(int(timestamp))
-                            processed_time_readable = str((datetime.datetime.now() - startTime_readable)).split('.')[0]
-
-                            if int(card) > 0:
-                                if int((datetime.datetime.now() - startTime_readable).total_seconds()) > threshold_stucked_module:
-                                    log = open(log_filename, 'a')
-                                    log.write(json.dumps([queue, card, str(startTime_readable), str(processed_time_readable), path]) + "\n")
-                                    try:
-                                        last_kill_try = time.time() - lastTimeKillCommand[moduleNum]
-                                    except KeyError:
-                                        last_kill_try = kill_retry_threshold+1
-                                    if args.autokill == 1 and last_kill_try > kill_retry_threshold :
-                                        kill_module(queue, int(moduleNum))
-
-                                array_module_type.append([get_color(processed_time_readable, False) + str(queue), str(moduleNum), str(card), str(startTime_readable), str(processed_time_readable), str(path) + get_color(None, False)])
-
-                            else:
-                                printarray2.append([get_color(processed_time_readable, True) + str(queue), str(moduleNum), str(card), str(startTime_readable), str(processed_time_readable), str(path) + get_color(None, True)])
-                        array_module_type.sort(lambda x,y: cmp(x[4], y[4]), reverse=True)
-                for e in array_module_type:
-                    printarray1.append(e)
-
-            for curr_queue in module_file_array:
-                if curr_queue not in all_queue:
-                        printarray3.append([curr_queue, "Not running"])
-                else:
-                    if len(list(server.smembers('MODULE_TYPE_'+curr_queue))) == 0:
-                        if curr_queue not in no_info_modules:
-                            no_info_modules[curr_queue] = int(time.time())
-                            printarray3.append([curr_queue, "No data"])
-                        else:
-                            #If no info since long time, try to kill
-                            if args.autokill == 1 and int(time.time()) - no_info_modules[curr_queue] > threshold_stucked_module:
-                                kill_module(curr_queue, None)
+                #key = ''
+                #while key != 'q':
+                #    key = stdsrc.getch()
+                #    stdscr.refresh()
+    
+                all_queue = set()
+                printarray1 = []
+                printarray2 = []
+                printarray3 = []
+                for queue, card in server.hgetall("queues").iteritems():
+                    all_queue.add(queue)
+                    key = "MODULE_" + queue + "_"
+                    keySet = "MODULE_TYPE_" + queue
+                    array_module_type = []
+    
+                    for moduleNum in server.smembers(keySet):
+                        value = server.get(key + str(moduleNum))
+                        if value is not None:
+                            timestamp, path = value.split(", ")
+                            if timestamp is not None and path is not None:
+                                startTime_readable = datetime.datetime.fromtimestamp(int(timestamp))
+                                processed_time_readable = str((datetime.datetime.now() - startTime_readable)).split('.')[0]
+    
+                                if int(card) > 0:
+                                    if int((datetime.datetime.now() - startTime_readable).total_seconds()) > args.treshold:
+                                        log = open(log_filename, 'a')
+                                        log.write(json.dumps([queue, card, str(startTime_readable), str(processed_time_readable), path]) + "\n")
+                                        try:
+                                            last_kill_try = time.time() - lastTimeKillCommand[moduleNum]
+                                        except KeyError:
+                                            last_kill_try = kill_retry_threshold+1
+                                        if args.autokill == 1 and last_kill_try > kill_retry_threshold :
+                                            kill_module(queue, int(moduleNum))
+    
+                                    array_module_type.append([get_color(processed_time_readable, False) + str(queue), str(moduleNum), str(card), str(startTime_readable), str(processed_time_readable), str(path) + get_color(None, False)])
+    
+                                else:
+                                    printarray2.append([get_color(processed_time_readable, True) + str(queue), str(moduleNum), str(card), str(startTime_readable), str(processed_time_readable), str(path) + get_color(None, True)])
+                            array_module_type.sort(lambda x,y: cmp(x[4], y[4]), reverse=True)
+                    for e in array_module_type:
+                        printarray1.append(e)
+    
+                for curr_queue in module_file_array:
+                    if curr_queue not in all_queue:
+                            printarray3.append([curr_queue, "Not running"])
+                    else:
+                        if len(list(server.smembers('MODULE_TYPE_'+curr_queue))) == 0:
+                            if curr_queue not in no_info_modules:
                                 no_info_modules[curr_queue] = int(time.time())
-                            printarray3.append([curr_queue, "Stuck or idle, restarting in " + str(threshold_stucked_module - (int(time.time()) - no_info_modules[curr_queue])) + "s"])
-
-
-            #printarray1.sort(lambda x,y: cmp(x[0], y[0]), reverse=False)
-            printarray1.sort(key=lambda x: x[0][9:], reverse=False)
-            #printarray2.sort(lambda x,y: cmp(x[0], y[0]), reverse=False)
-            printarray2.sort(key=lambda x: x[0][9:], reverse=False)
-            printarray1.insert(0,["Queue", "PID", "Amount", "Paste start time", "Processing time for current paste (H:M:S)", "Paste hash"])
-            printarray2.insert(0,["Queue", "PID","Amount", "Paste start time", "Time since idle (H:M:S)", "Last paste hash"])
-            printarray3.insert(0,["Queue", "State"])
-
-            os.system('clear')
-            t1 = AsciiTable(printarray1, title="Working queues")
-            t1.column_max_width(1)
-            if not t1.ok:
-                    longest_col = t1.column_widths.index(max(t1.column_widths))
-                    max_length_col = t1.column_max_width(longest_col)
-                    if max_length_col > 0:
-                        for i, content in enumerate(t1.table_data):
-                            if len(content[longest_col]) > max_length_col:
-                                temp = ''
-                                for l in content[longest_col].splitlines():
-                                    if len(l) > max_length_col:
-                                        temp += '\n'.join(textwrap.wrap(l, max_length_col)) + '\n'
-                                    else:
-                                        temp += l + '\n'
-                                    content[longest_col] = temp.strip()
-                            t1.table_data[i] = content
-
-            t2 = AsciiTable(printarray2, title="Idling queues")
-            t2.column_max_width(1)
-            if not t2.ok:
-                    longest_col = t2.column_widths.index(max(t2.column_widths))
-                    max_length_col = t2.column_max_width(longest_col)
-                    if max_length_col > 0:
-                        for i, content in enumerate(t2.table_data):
-                            if len(content[longest_col]) > max_length_col:
-                                temp = ''
-                                for l in content[longest_col].splitlines():
-                                    if len(l) > max_length_col:
-                                        temp += '\n'.join(textwrap.wrap(l, max_length_col)) + '\n'
-                                    else:
-                                        temp += l + '\n'
-                                    content[longest_col] = temp.strip()
-                            t2.table_data[i] = content
-
-            t3 = AsciiTable(printarray3, title="Not running queues")
-            t3.column_max_width(1)
-
-            printarray4 = []
-            for elem in printarrayGlob:
-                if elem is not None:
-                    printarray4.append(elem)
-
-            t4 = AsciiTable(printarray4, title="Last actions")
-            t4.column_max_width(1)
-
-            print t1.table
-            print '\n'
-            print t2.table
-            print '\n'
-            print t3.table
-            print '\n'
-            print t4.table
-
-            if (datetime.datetime.now() - lastTime).total_seconds() > args.refresh*5: 
-                lastTime = datetime.datetime.now()
-                cleanRedis()
-            time.sleep(args.refresh)
+                                printarray3.append([curr_queue, "No data"])
+                            else:
+                                #If no info since long time, try to kill
+                                if args.autokill == 1:
+                                    if int(time.time()) - no_info_modules[curr_queue] > args.treshold:
+                                        kill_module(curr_queue, None)
+                                        no_info_modules[curr_queue] = int(time.time())
+                                    printarray3.append([curr_queue, "Stuck or idle, restarting in " + str(abs(args.treshold - (int(time.time()) - no_info_modules[curr_queue]))) + "s"])
+                                else:
+                                    printarray3.append([curr_queue, "Stuck or idle, restarting disabled"])
+    
+                ## FIXME To add:
+                ## Button KILL Process using  Curses
+    
+                printarray1.sort(key=lambda x: x[0][9:], reverse=False)
+                printarray2.sort(key=lambda x: x[0][9:], reverse=False)
+                printarray1.insert(0,["Queue", "PID", "Amount", "Paste start time", "Processing time for current paste (H:M:S)", "Paste hash"])
+                printarray2.insert(0,["Queue", "PID","Amount", "Paste start time", "Time since idle (H:M:S)", "Last paste hash"])
+                printarray3.insert(0,["Queue", "State"])
+    
+                os.system('clear')
+                t1 = AsciiTable(printarray1, title="Working queues")
+                t1.column_max_width(1)
+                if not t1.ok:
+                        longest_col = t1.column_widths.index(max(t1.column_widths))
+                        max_length_col = t1.column_max_width(longest_col)
+                        if max_length_col > 0:
+                            for i, content in enumerate(t1.table_data):
+                                if len(content[longest_col]) > max_length_col:
+                                    temp = ''
+                                    for l in content[longest_col].splitlines():
+                                        if len(l) > max_length_col:
+                                            temp += '\n'.join(textwrap.wrap(l, max_length_col)) + '\n'
+                                        else:
+                                            temp += l + '\n'
+                                        content[longest_col] = temp.strip()
+                                t1.table_data[i] = content
+    
+                t2 = AsciiTable(printarray2, title="Idling queues")
+                t2.column_max_width(1)
+                if not t2.ok:
+                        longest_col = t2.column_widths.index(max(t2.column_widths))
+                        max_length_col = t2.column_max_width(longest_col)
+                        if max_length_col > 0:
+                            for i, content in enumerate(t2.table_data):
+                                if len(content[longest_col]) > max_length_col:
+                                    temp = ''
+                                    for l in content[longest_col].splitlines():
+                                        if len(l) > max_length_col:
+                                            temp += '\n'.join(textwrap.wrap(l, max_length_col)) + '\n'
+                                        else:
+                                            temp += l + '\n'
+                                        content[longest_col] = temp.strip()
+                                t2.table_data[i] = content
+    
+                t3 = AsciiTable(printarray3, title="Not running queues")
+                t3.column_max_width(1)
+    
+                printarray4 = []
+                for elem in printarrayGlob:
+                    if elem is not None:
+                        printarray4.append(elem)
+    
+                t4 = AsciiTable(printarray4, title="Last actions")
+                t4.column_max_width(1)
+    
+                legend_array = [["Color", "Meaning"], [Back.RED+Style.BRIGHT+" "*10+Style.RESET_ALL, "Time >=" +str(args.treshold)+Style.RESET_ALL], [Back.MAGENTA+Style.BRIGHT+" "*10+Style.RESET_ALL, "Time >=" +str(args.treshold)+" while idle"+Style.RESET_ALL], [Back.YELLOW+Style.BRIGHT+" "*10+Style.RESET_ALL, "Time >=" +str(args.treshold/2)+Style.RESET_ALL], [Back.GREEN+Style.BRIGHT+" "*10+Style.RESET_ALL, "Time <" +str(args.treshold)]]
+                legend = AsciiTable(legend_array, title="Legend")
+                legend.column_max_width(1)
+    
+                print legend.table
+                print '\n'
+                print t1.table
+                print '\n'
+                print t2.table
+                print '\n'
+                print t3.table
+                print '\n'
+                print t4.table
+    
+                if (datetime.datetime.now() - lastTime).total_seconds() > args.refresh*5: 
+                    lastTime = datetime.datetime.now()
+                    cleanRedis()
+                #time.sleep(args.refresh)

--- a/bin/packages/config.cfg.sample
+++ b/bin/packages/config.cfg.sample
@@ -72,11 +72,10 @@ host = localhost
 port = 6379
 db = 2
 
-[Redis_Mixer]
+[Redis_Mixer_Cache]
 host = localhost
 port = 6381
 db = 1
-channel = 102
 
 ##### LevelDB #####
 [Redis_Level_DB_Curve]

--- a/bin/packages/config.cfg.sample
+++ b/bin/packages/config.cfg.sample
@@ -40,6 +40,12 @@ min_paste_size = 0.3
 #Threshold to deduce if a module is stuck or not, in seconds.
 threshold_stucked_module=600
 
+[Module_Mixer]
+#Define the configuration of the mixer, possible value: 1 or 2
+operation_mode = 1
+#Define the time that a paste will be considerate duplicate. in seconds (1day = 86400)
+ttl_duplicate = 86400
+
 ##### Redis #####
 [Redis_Cache]
 host = localhost
@@ -65,6 +71,12 @@ db = 1
 host = localhost
 port = 6379
 db = 2
+
+[Redis_Mixer]
+host = localhost
+port = 6381
+db = 1
+channel = 102
 
 ##### LevelDB #####
 [Redis_Level_DB_Curve]
@@ -111,6 +123,8 @@ path = indexdir
 
 ###############################################################################
 
+# For multiple feed, add them with "," without space
+# e.g.: tcp://127.0.0.1:5556,tcp://127.0.0.1:5557
 [ZMQ_Global]
 #address = tcp://crf.circl.lu:5556
 address = tcp://127.0.0.1:5556

--- a/bin/packages/modules.cfg
+++ b/bin/packages/modules.cfg
@@ -1,5 +1,9 @@
-[Global]
+[Mixer]
 subscribe = ZMQ_Global
+publish = Redis_Mixer
+
+[Global]
+subscribe = Redis_Mixer
 publish = Redis_Global,Redis_ModuleStats
 
 [Duplicates]

--- a/bin/packages/modules.cfg
+++ b/bin/packages/modules.cfg
@@ -1,10 +1,14 @@
 [Mixer]
 subscribe = ZMQ_Global
-publish = Redis_Mixer
+publish = Redis_Mixer,Redis_preProcess1
 
 [Global]
 subscribe = Redis_Mixer
 publish = Redis_Global,Redis_ModuleStats
+
+[PreProcessFeed]
+subscribe = Redis_preProcess1
+publish = Redis_Mixer
 
 [Duplicates]
 subscribe = Redis_Duplicate

--- a/bin/preProcessFeed.py
+++ b/bin/preProcessFeed.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python2
+# -*-coding:UTF-8 -*
+
+import time
+from pubsublogger import publisher
+
+from Helper import Process
+
+
+def do_something(message):
+    splitted = message.split()
+    if len(splitted) == 2:
+        paste_name, gzip64encoded = splitted
+
+    paste_name = paste_name.replace("pastebin", "pastebinPROCESSED")
+
+    to_send = "{0} {1}".format(paste_name, gzip64encoded)
+    return to_send
+
+if __name__ == '__main__':
+    # If you wish to use an other port of channel, do not forget to run a subscriber accordingly (see launch_logs.sh)
+    # Port of the redis instance used by pubsublogger
+    publisher.port = 6380
+    # Script is the default channel used for the modules.
+    publisher.channel = 'Script'
+
+    # Section name in bin/packages/modules.cfg
+    config_section = 'PreProcessFeed'
+
+    # Setup the I/O queues
+    p = Process(config_section)
+
+    # Sent to the logging a description of the module
+    publisher.info("<description of the module>")
+
+    # Endless loop getting messages from the input queue
+    while True:
+        # Get one message from the input queue
+        message = p.get_from_set()
+        if message is None:
+            publisher.debug("{} queue is empty, waiting".format(config_section))
+            print "queue empty"
+            time.sleep(1)
+            continue
+
+        # Do something with the message from the queue
+        new_message = do_something(message)
+
+        # (Optional) Send that thing to the next queue
+        p.populate_set_out(new_message)

--- a/var/www/Flasks/Flask_trendingmodules.py
+++ b/var/www/Flasks/Flask_trendingmodules.py
@@ -63,6 +63,7 @@ def modulesCharts():
 
     else:
         member_set = get_top_relevant_data(r_serv_charts, module_name)
+        member_set = member_set if member_set is not None else []
         if len(member_set) == 0:
             member_set.append(("No relevant data", int(100)))
         return jsonify(member_set)

--- a/var/www/Flasks/Flask_trendingmodules.py
+++ b/var/www/Flasks/Flask_trendingmodules.py
@@ -6,6 +6,7 @@
 '''
 import redis
 import datetime
+from Date import Date
 import flask
 from flask import Flask, render_template, jsonify, request
 

--- a/var/www/static/js/indexjavascript.js
+++ b/var/www/static/js/indexjavascript.js
@@ -1,6 +1,6 @@
 var time_since_last_pastes_num = {};
 var data_for_processed_paste = { "global": [] };
-var list_feeder = ["global"];
+var list_feeder = [];
 var htmltext_graph_container = "<div class=\"col-lg-6\"> <div id=\"$1\" style=\"height: 90px; padding: 0px; position: relative;\"></div></div>";
 window.paste_num_tabvar_all = {};
 
@@ -134,8 +134,11 @@ function create_log_table(obj_json) {
         var msg_type = parsedmess[4].split(" ")[2]; 
 
         if (feeder == "All_feeders"){
-           var total_proc = $.plot("#global", [ getData("global") ], options_processed_pastes);
-           update_processed_pastes(total_proc, "global");
+            if(list_feeder.indexOf("global") == -1) {
+                list_feeder.push("global");
+                var total_proc = $.plot("#global", [ getData("global") ], options_processed_pastes);
+                update_processed_pastes(total_proc, "global");
+            }
            window.paste_num_tabvar_all["global"] = paste_processed;
            time_since_last_pastes_num["global"] = new Date().getTime();
         } else {

--- a/var/www/static/js/indexjavascript.js
+++ b/var/www/static/js/indexjavascript.js
@@ -33,7 +33,7 @@ function update_values() {
 // BEGIN PROCESSED PASTES
     var default_minute = (typeof window.default_minute !== "undefined") ? parseInt(window.default_minute) : 10;
     var totalPoints = 60*parseInt(default_minute); //60s*minute
-    var curr_max = 0;
+    var curr_max = {"global": 0};
     
     function getData(dataset) {
         var curr_data;
@@ -44,14 +44,14 @@ function update_values() {
 
         if (curr_data.length > 0){
              var data_old = curr_data[0];
-             curr_data = curr_data.slice(1);
-             curr_max = curr_max == data_old ? Math.max.apply(null, curr_data) : curr_max;
+             curr_data = curr_data.slice(10);
+             curr_max[dataset] = curr_max[dataset] == data_old ? Math.max.apply(null, curr_data) : curr_max[dataset];
         }
         
         while (curr_data.length < totalPoints) {
             //var y = (typeof window.paste_num_tabvar_all[dataset] !== "undefined") ? parseInt(window.paste_num_tabvar_all[dataset]) : 0;
             var y = (typeof window.paste_num_tabvar_all[dataset] !== "undefined") ? parseInt(window.paste_num_tabvar_all[dataset]) : 0;
-            curr_max = y > curr_max ? y : curr_max;
+            curr_max[dataset] = y > curr_max[dataset] ? y : curr_max[dataset];
             curr_data.push(y);
         }
         // Zip the generated y values with the x values
@@ -63,7 +63,7 @@ function update_values() {
         return res;
     }
 
-    var updateInterval = 1000;
+    var updateInterval = 10000;
     var options_processed_pastes = {
         series: { shadowSize: 1 },
         lines: { fill: true, fillColor: { colors: [ { opacity: 1 }, { opacity: 0.1 } ] }},
@@ -74,16 +74,14 @@ function update_values() {
             borderWidth: 0 
         },
     };
-    var total_proc = $.plot("#global", [ getData("global") ], options_processed_pastes);
 
     function update_processed_pastes(graph, dataset) {
         graph.setData([getData(dataset)]);
-        graph.getOptions().yaxes[0].max = curr_max;
+        graph.getOptions().yaxes[0].max = curr_max[dataset];
         graph.setupGrid();
         graph.draw();
         setTimeout(function(){ update_processed_pastes(graph, dataset); }, updateInterval);
     }
-    update_processed_pastes(total_proc, "global");
 
 
 // END PROCESSED PASTES    
@@ -136,6 +134,8 @@ function create_log_table(obj_json) {
         var msg_type = parsedmess[4].split(" ")[2]; 
 
         if (feeder == "All_feeders"){
+           var total_proc = $.plot("#global", [ getData("global") ], options_processed_pastes);
+           update_processed_pastes(total_proc, "global");
            window.paste_num_tabvar_all["global"] = paste_processed;
            time_since_last_pastes_num["global"] = new Date().getTime();
         } else {

--- a/var/www/templates/index.html
+++ b/var/www/templates/index.html
@@ -100,7 +100,8 @@
                         <div id="panelbody" class="panel-body" style="height:420px;">
 
                        <strong>Processed pastes</strong>
-                       <div id="Proc_feeder" style="height: 250px; padding: 0px; position: relative;"></div>
+                       <div id="Proc_feeder" style="height: 230px; padding: 0px; position: relative;"></div>
+                       <hr style="border-top: 2px solid #eee; margin-top: 7px; margin-bottom: 7px;">
                        <strong>Filtered duplicated</strong>
                        <div id="Dup_feeder" style="height: 100px; padding: 0px; position: relative;"></div>
 

--- a/var/www/templates/index.html
+++ b/var/www/templates/index.html
@@ -17,6 +17,7 @@
   <script type="text/javascript" src="{{ url_for('static', filename='js/dygraph-combined.js') }}"></script>
   <script src="{{ url_for('static', filename='js/jquery.js') }}"></script>
   <script src="{{ url_for('static', filename='js/jquery.flot.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/jquery.flot.time.js') }}"></script>
   <script>
       window.default_minute = {{ default_minute }};
       window.glob_tabvar = []; // Avoid undefined
@@ -98,7 +99,9 @@
                         </div>
                         <div id="panelbody" class="panel-body" style="height:420px;">
 
-                        
+                       <div id="Proc_feeder" style="height: 200px; padding: 0px; position: relative;"></div>
+                       <div id="Dup_feeder" style="height: 200px; padding: 0px; position: relative;"></div>
+
                         </div>
                      <!-- /.panel-body -->
                      </div>

--- a/var/www/templates/index.html
+++ b/var/www/templates/index.html
@@ -52,10 +52,10 @@
               <!-- /.sidebar-collapse -->
               <div class="panel panel-default">
                   <div class="panel-heading">
-                      <i class="fa fa-dashboard  fa-fw"></i> Pastes since {{ default_minute }} min
+                      <i class="fa fa-dashboard  fa-fw"></i> Total pastes since {{ default_minute }} min
                   </div>
                   <div class="panel-body">
-                       <div id="realtimechart" style="height: 90px; padding: 0px; position: relative;"></div>
+                       <div id="global" style="height: 90px; padding: 0px; position: relative;"></div>
                   </div>
               </div>
                   <!-- <div id="Graph_paste_num" style="height:90px; width:100%;"></div> -->
@@ -91,23 +91,38 @@
         </div>
 
             <div class="row">
-                      <div class="col-lg-12">
-                      <div class="panel panel-default">
-                      <div class="panel-heading">
-                        <i class="fa fa-bar-chart-o fa-fw"></i> Queues Monitor
-                      </div>
-                        <div class="panel-body">
-                            <div class="row">
-                                <div class="col-lg-6" id="Graph" style="height:400px; width:48%;"></div>
-                                <div class="col-lg-6" id="Graph2" style="height:400px; width:48%;"></div>
-                            </div>
-                            <!-- /.row -->
+                 <div class="col-lg-8">
+                     <div class="panel panel-default">
+                        <div class="panel-heading">
+                           <i class="fa fa-bar-chart-o fa-fw"></i> <i class="fa fa-dashboard  fa-fw"></i> <i class="fa fa-copy"></i>Feeder(s) Monitor: Processed pastes and filtered duplicated
                         </div>
-                        <!-- /.panel-body -->
-                    </div>
-                    <!-- /.panel -->
-                </div>
-                <!-- /.col-lg-8 -->
+                        <div id="panelbody" class="panel-body" style="height:489px;">
+
+                        
+                        </div>
+                     <!-- /.panel-body -->
+                     </div>
+                      <!-- /.panel -->
+                 </div>
+                 <!-- /.col-lg-6 -->
+                 <div class="col-lg-4">
+                     <div class="panel panel-default">
+                        <div class="panel-heading">
+                           <i class="fa fa-bar-chart-o fa-fw"></i> Queues Monitor
+                        </div>
+                        <div class="panel-body">
+                           <div class="row">
+                               <div class="col-lg-6" id="Graph" style="height:195px; width:88%;"></div>
+                               <div style="height:10px;"></div>
+                               <div class="col-lg-6" id="Graph2" style="height:195px; width:88%;"></div>
+                           </div>
+                        <!-- /.row -->
+                        </div>
+                     <!-- /.panel-body -->
+                     </div>
+                      <!-- /.panel -->
+                 </div>
+                 <!-- /.col-lg-6 -->
         <div class="col-lg-12">
         <div class="panel panel-default">
         <div class="panel-heading">

--- a/var/www/templates/index.html
+++ b/var/www/templates/index.html
@@ -95,12 +95,14 @@
                  <div class="col-lg-6">
                      <div class="panel panel-default">
                         <div class="panel-heading">
-                           <i class="fa fa-bar-chart-o fa-fw"></i> Feeder(s) Monitor: Processed pastes and filtered duplicated
+                           <i class="fa fa-bar-chart-o fa-fw"></i> Feeder(s) Monitor:
                         </div>
                         <div id="panelbody" class="panel-body" style="height:420px;">
 
-                       <div id="Proc_feeder" style="height: 200px; padding: 0px; position: relative;"></div>
-                       <div id="Dup_feeder" style="height: 200px; padding: 0px; position: relative;"></div>
+                       <strong>Processed pastes</strong>
+                       <div id="Proc_feeder" style="height: 250px; padding: 0px; position: relative;"></div>
+                       <strong>Filtered duplicated</strong>
+                       <div id="Dup_feeder" style="height: 100px; padding: 0px; position: relative;"></div>
 
                         </div>
                      <!-- /.panel-body -->

--- a/var/www/templates/index.html
+++ b/var/www/templates/index.html
@@ -91,12 +91,12 @@
         </div>
 
             <div class="row">
-                 <div class="col-lg-8">
+                 <div class="col-lg-6">
                      <div class="panel panel-default">
                         <div class="panel-heading">
-                           <i class="fa fa-bar-chart-o fa-fw"></i> <i class="fa fa-dashboard  fa-fw"></i> <i class="fa fa-copy"></i>Feeder(s) Monitor: Processed pastes and filtered duplicated
+                           <i class="fa fa-bar-chart-o fa-fw"></i> Feeder(s) Monitor: Processed pastes and filtered duplicated
                         </div>
-                        <div id="panelbody" class="panel-body" style="height:489px;">
+                        <div id="panelbody" class="panel-body" style="height:420px;">
 
                         
                         </div>
@@ -105,7 +105,7 @@
                       <!-- /.panel -->
                  </div>
                  <!-- /.col-lg-6 -->
-                 <div class="col-lg-4">
+                 <div class="col-lg-6">
                      <div class="panel panel-default">
                         <div class="panel-heading">
                            <i class="fa fa-bar-chart-o fa-fw"></i> Queues Monitor


### PR DESCRIPTION
## Modifications
- Modified helper.py to handle multiple zmq feeds
- Created the Mixer.py module which can run in 2 operations modes
	- operation_mode 1: Avoid any duplicates from any sources
	- operation_mode 2: Relay duplicates coming from different sources
	- It could also be used to preprocess the feed before relaying it
- Improved dashboard layout and scripts
- Fixed some small bugs and dependencies

## Note
- The name of the feed must be appened (with '>') to the paste's name: e.g. feeder1>paste_name. If the feed has no name, it's set unnamed by default.