### PR TITLE
Fixed bug in Categ and Mail

### DIFF
--- a/bin/Categ.py
+++ b/bin/Categ.py
@@ -98,4 +98,4 @@ if __name__ == "__main__":
                 publisher.info(
                     'Categ;{};{};{};Detected {} as {};{}'.format(
                         paste.p_source, paste.p_date, paste.p_name,
-                        len(found), categ), paste.p_path)
+                        len(found), categ, paste.p_path))

--- a/bin/Mail.py
+++ b/bin/Mail.py
@@ -62,6 +62,7 @@ if __name__ == "__main__":
                         publisher.warning(to_print)
                         #Send to duplicate
                         p.populate_set_out(filename, 'Duplicate')
+                        p.populate_set_out('mail;{}'.format(filename), 'BrowseWarningPaste')
                         
                     else:
                         publisher.info(to_print)
@@ -69,7 +70,6 @@ if __name__ == "__main__":
                 for mail in MX_values[1]:
                     print 'mail;{};{};{}'.format(1, mail, PST.p_date)
                     p.populate_set_out('mail;{};{};{}'.format(1, mail, PST.p_date), 'ModuleStats')
-                    p.populate_set_out('mail;{}'.format(filename), 'BrowseWarningPaste')
 
             prec_filename = filename
 


### PR DESCRIPTION
- Fixed the bug introduced in d4da3a316f18f36f9c61e7c0a5cc601898fa489a in Categ (closing parenthesis)
- Changed behavior of Mail: Now, it sends matched mails to BrowseWarningPaste only if number of matched mail > critical value  