### PR TITLE
Moving more to config

### DIFF
--- a/bin/Categ.py
+++ b/bin/Categ.py
@@ -52,6 +52,7 @@ if __name__ == "__main__":
     config_section = 'Categ'
 
     p = Process(config_section)
+    matchingThreshold = p.config.getint("Categ", "matchingThreshold")
 
     # SCRIPT PARSER #
     parser = argparse.ArgumentParser(description='Start Categ module on files.')
@@ -90,7 +91,7 @@ if __name__ == "__main__":
 
         for categ, pattern in tmp_dict.items():
             found = set(re.findall(pattern, content))
-            if len(found) > 0:
+            if len(found) >= matchingThreshold:
                 msg = '{} {}'.format(paste.p_path, len(found))
                 print msg, categ
                 p.populate_set_out(msg, categ)

--- a/bin/Mixer.py
+++ b/bin/Mixer.py
@@ -20,7 +20,7 @@ Depending on the configuration, this module will process the feed as follow:
             - Else, do not process it but keep track for statistics on duplicate
 
     operation_mode 3: "Don't look if duplicate"
-        - SImply do not bother to check if it is a duplicate
+        - Simply do not bother to check if it is a duplicate
 
 Note that the hash of the content is defined as the sha1(gzip64encoded).
 

--- a/bin/Mixer.py
+++ b/bin/Mixer.py
@@ -19,7 +19,7 @@ Depending on the configuration, this module will process the feed as follow:
             - Elseif, the saved content associated with the paste is not the same, process it
             - Else, do not process it but keep track for statistics on duplicate
 
-    operation_mode 3: "Don't look if duplicate"
+    operation_mode 3: "Don't look if duplicated content"
         - Simply do not bother to check if it is a duplicate
 
 Note that the hash of the content is defined as the sha1(gzip64encoded).
@@ -126,7 +126,7 @@ if __name__ == '__main__':
 
                 # Keep duplicate coming from different sources
                 elif operation_mode == 2:
-                    # Filter to avoid duplicate 
+                    # Filter to avoid duplicate
                     content = server.get('HASH_'+paste_name)
                     if content is None:
                         # New content

--- a/bin/packages/config.cfg.sample
+++ b/bin/packages/config.cfg.sample
@@ -30,6 +30,18 @@ default_display = 10
 minute_processed_paste = 10
 
 #### Modules #### 
+[Categ]
+#Minimum number of match between the paste and the category file
+matchingThreshold=1
+
+[Credentials]
+#Minimum length that a credential must have to be considered as such
+minimumLengthThreshold=3
+#Will be pushed as alert if the number of credentials is greater to that number
+criticalNumberToAlert=8
+#Will be considered as false positive if less that X matches from the top password list
+minTopPassList=5
+
 [Modules_Duplicates]
 #Number of month to look back
 maximum_month_range = 3
@@ -45,8 +57,8 @@ min_paste_size = 0.3
 threshold_stucked_module=600
 
 [Module_Mixer]
-#Define the configuration of the mixer, possible value: 1 or 2
-operation_mode = 1
+#Define the configuration of the mixer, possible value: 1, 2 or 3
+operation_mode = 3
 #Define the time that a paste will be considerate duplicate. in seconds (1day = 86400)
 ttl_duplicate = 86400
 

--- a/bin/packages/config.cfg.sample
+++ b/bin/packages/config.cfg.sample
@@ -34,7 +34,7 @@ minute_processed_paste = 10
 #Minimum number of match between the paste and the category file
 matchingThreshold=1
 
-[Credentials]
+[Credential]
 #Minimum length that a credential must have to be considered as such
 minimumLengthThreshold=3
 #Will be pushed as alert if the number of credentials is greater to that number
@@ -151,7 +151,7 @@ maxDuplicateToPushToMISP=10
 # e.g.: tcp://127.0.0.1:5556,tcp://127.0.0.1:5557
 [ZMQ_Global]
 #address = tcp://crf.circl.lu:5556
-address = tcp://127.0.0.1:5556
+address = tcp://127.0.0.1:5556,tcp://crf.circl.lu:5556
 channel = 102
 bind = tcp://127.0.0.1:5556
 


### PR DESCRIPTION
Moving **filtering** operation performed inside ```categ.py``` and ```Credential.py``` to the configuration file. This is done to better control the flow of pastes.

Also, changed default filtering operation mode of ```Mixer.py``` from 1 (Avoid any duplicate from any sources) to 3 (Don't look if duplicated content). This is done to avoid confusion while re-processing data.
Solve issue #160 

- Categ: 
    - Threshold (on the number of matching keyword in the categ file) to publish to the deduced category module
- Credential:
    - Minimum credential character length
    - Critical number of credential to make an alert
    - Minimum number of credential that must be present in the top password list