### PR TITLE
Show differences between duplicates

### DIFF
--- a/bin/Categ.py
+++ b/bin/Categ.py
@@ -52,6 +52,7 @@ if __name__ == "__main__":
     config_section = 'Categ'
 
     p = Process(config_section)
+    matchingThreshold = p.config.getint("Categ", "matchingThreshold")
 
     # SCRIPT PARSER #
     parser = argparse.ArgumentParser(description='Start Categ module on files.')
@@ -90,7 +91,7 @@ if __name__ == "__main__":
 
         for categ, pattern in tmp_dict.items():
             found = set(re.findall(pattern, content))
-            if len(found) > 0:
+            if len(found) >= matchingThreshold:
                 msg = '{} {}'.format(paste.p_path, len(found))
                 print msg, categ
                 p.populate_set_out(msg, categ)

--- a/bin/Mixer.py
+++ b/bin/Mixer.py
@@ -19,7 +19,7 @@ Depending on the configuration, this module will process the feed as follow:
             - Elseif, the saved content associated with the paste is not the same, process it
             - Else, do not process it but keep track for statistics on duplicate
 
-    operation_mode 3: "Don't look if duplicate"
+    operation_mode 3: "Don't look if duplicated content"
         - SImply do not bother to check if it is a duplicate
 
 Note that the hash of the content is defined as the sha1(gzip64encoded).
@@ -126,7 +126,7 @@ if __name__ == '__main__':
 
                 # Keep duplicate coming from different sources
                 elif operation_mode == 2:
-                    # Filter to avoid duplicate 
+                    # Filter to avoid duplicate
                     content = server.get('HASH_'+paste_name)
                     if content is None:
                         # New content

--- a/bin/Mixer.py
+++ b/bin/Mixer.py
@@ -21,6 +21,7 @@ Depending on the configuration, this module will process the feed as follow:
 
     operation_mode 3: "Don't look if duplicated content"
         - SImply do not bother to check if it is a duplicate
+        - Simply do not bother to check if it is a duplicate
 
 Note that the hash of the content is defined as the sha1(gzip64encoded).
 

--- a/bin/packages/config.cfg.sample
+++ b/bin/packages/config.cfg.sample
@@ -21,15 +21,17 @@ sentiment_lexicon_file = sentiment/vader_lexicon.zip/vader_lexicon/vader_lexicon
 ##### Flask #####
 [Flask]
 #Maximum number of character to display in the toolip
-max_preview_char = 250 
+max_preview_char = 250
 #Maximum number of character to display in the modal
-max_preview_modal = 800 
+max_preview_modal = 800
 #Default number of header to display in trending graphs
 default_display = 10
 #Number of minutes displayed for the number of processed pastes.
 minute_processed_paste = 10
+#Maximum line length authorized to make a diff between duplicates 
+DiffMaxLineLength = 10000
 
-#### Modules #### 
+#### Modules ####
 [Modules_Duplicates]
 #Number of month to look back
 maximum_month_range = 3

--- a/bin/packages/config.cfg.sample
+++ b/bin/packages/config.cfg.sample
@@ -32,6 +32,18 @@ minute_processed_paste = 10
 DiffMaxLineLength = 10000
 
 #### Modules ####
+[Categ]
+#Minimum number of match between the paste and the category file
+matchingThreshold=1
+
+[Credential]
+#Minimum length that a credential must have to be considered as such
+minimumLengthThreshold=3
+#Will be pushed as alert if the number of credentials is greater to that number
+criticalNumberToAlert=8
+#Will be considered as false positive if less that X matches from the top password list
+minTopPassList=5
+
 [Modules_Duplicates]
 #Number of month to look back
 maximum_month_range = 3
@@ -47,8 +59,8 @@ min_paste_size = 0.3
 threshold_stucked_module=600
 
 [Module_Mixer]
-#Define the configuration of the mixer, possible value: 1 or 2
-operation_mode = 1
+#Define the configuration of the mixer, possible value: 1, 2 or 3
+operation_mode = 3
 #Define the time that a paste will be considerate duplicate. in seconds (1day = 86400)
 ttl_duplicate = 86400
 
@@ -141,7 +153,7 @@ maxDuplicateToPushToMISP=10
 # e.g.: tcp://127.0.0.1:5556,tcp://127.0.0.1:5557
 [ZMQ_Global]
 #address = tcp://crf.circl.lu:5556
-address = tcp://127.0.0.1:5556
+address = tcp://127.0.0.1:5556,tcp://crf.circl.lu:5556
 channel = 102
 bind = tcp://127.0.0.1:5556
 

--- a/var/www/modules/Flask_config.py
+++ b/var/www/modules/Flask_config.py
@@ -63,3 +63,4 @@ max_preview_char = int(cfg.get("Flask", "max_preview_char")) # Maximum number of
 max_preview_modal = int(cfg.get("Flask", "max_preview_modal")) # Maximum number of character to display in the modal
 
 tlsh_to_percent = 1000.0 #Use to display the estimated percentage instead of a raw value
+DiffMaxLineLength =  int(cfg.get("Flask", "DiffMaxLineLength"))#Use to display the estimated percentage instead of a raw value

--- a/var/www/modules/showpaste/Flask_showpaste.py
+++ b/var/www/modules/showpaste/Flask_showpaste.py
@@ -7,7 +7,8 @@
 import redis
 import json
 import flask
-from flask import Flask, render_template, jsonify, request, Blueprint
+from flask import Flask, render_template, jsonify, request, Blueprint, make_response
+import difflib
 
 import Paste
 
@@ -112,6 +113,22 @@ def getmoredata():
     p_content = paste.get_p_content().decode('utf-8', 'ignore')
     to_return = p_content[max_preview_modal-1:]
     return to_return
+
+@showsavedpastes.route("/showDiff/")
+def showDiff():
+    s1 = request.args.get('s1', '')
+    s2 = request.args.get('s2', '')
+    p1 = Paste.Paste(s1)
+    p2 = Paste.Paste(s2)
+    maxLengthLine1 = p1.get_lines_info()[1]
+    maxLengthLine2 = p2.get_lines_info()[1]
+    if maxLengthLine1 > 100000 or maxLengthLine2 > 100000:
+        return "Can't make the difference as the lines are too long."
+    htmlD = difflib.HtmlDiff()
+    lines1 = p1.get_p_content().decode('utf8', 'ignore').splitlines()
+    lines2 = p2.get_p_content().decode('utf8', 'ignore').splitlines()
+    the_html = htmlD.make_file(lines1, lines2)
+    return the_html
 
 # ========= REGISTRATION =========
 app.register_blueprint(showsavedpastes)

--- a/var/www/modules/showpaste/Flask_showpaste.py
+++ b/var/www/modules/showpaste/Flask_showpaste.py
@@ -21,6 +21,7 @@ r_serv_pasteName = Flask_config.r_serv_pasteName
 max_preview_char = Flask_config.max_preview_char
 max_preview_modal = Flask_config.max_preview_modal
 tlsh_to_percent = Flask_config.tlsh_to_percent
+DiffMaxLineLength = Flask_config.DiffMaxLineLength
 
 showsavedpastes = Blueprint('showsavedpastes', __name__, template_folder='templates')
 
@@ -122,7 +123,7 @@ def showDiff():
     p2 = Paste.Paste(s2)
     maxLengthLine1 = p1.get_lines_info()[1]
     maxLengthLine2 = p2.get_lines_info()[1]
-    if maxLengthLine1 > 100000 or maxLengthLine2 > 100000:
+    if maxLengthLine1 > DiffMaxLineLength or maxLengthLine2 > DiffMaxLineLength:
         return "Can't make the difference as the lines are too long."
     htmlD = difflib.HtmlDiff()
     lines1 = p1.get_p_content().decode('utf8', 'ignore').splitlines()

--- a/var/www/modules/showpaste/templates/show_saved_paste.html
+++ b/var/www/modules/showpaste/templates/show_saved_paste.html
@@ -15,14 +15,14 @@
    <script src="{{ url_for('static', filename='js/dataTables.bootstrap.js') }}"></script>
    <script src="{{ url_for('static', filename='js/jquery.flot.js') }}"></script>
    <script src="{{ url_for('static', filename='js/jquery.flot.time.js') }}"></script>
-   <script src="{{ url_for('static', filename='js/jquery.flot.stack.js') }}"></script>     
+   <script src="{{ url_for('static', filename='js/jquery.flot.stack.js') }}"></script>
 </head>
 <body>
     <div class="panel panel-default">
       <div class="panel-heading">
         <h1 class="page-header" >Paste: {{ request.args.get('paste') }}</h1>
         <h2 class="page-header" >({{ request.args.get('num') }})</h2>
-  
+
         <table class="table table-condensed">
           <thead>
             <tr>
@@ -62,7 +62,8 @@
               <th>Hash type</th>
               <th>Paste info</th>
               <th>Date</th>
-              <th>Path</th> 
+              <th>Path</th>
+              <th>Action</th>
           </tr>
           </thead>
           <tbody>
@@ -72,6 +73,7 @@
                   <td>Similarity: {{ simil_list[i] }}%</td>
                   <td>{{ date_list[i] }}</td>
                   <td><a target="_blank" href="{{ url_for('showsavedpastes.showsavedpaste') }}?paste={{ dup_path }}" id='dup_path'>{{ dup_path }}</a></td>
+                  <td><a target="_blank" href="{{ url_for('showsavedpastes.showDiff') }}?s1={{ request.args.get('paste') }}&s2={{ dup_path }}" class="fa fa-columns" title="Show differences"></a></td>
               </tr>
               {% set i = i + 1 %}
           {% endfor %}
@@ -82,7 +84,7 @@
         <p data-initsize="{{ initsize }}"> <pre id="paste-holder">{{ content }}</pre></p>
       </div>
     </div>
-  
+
 </body>
 <script>
     $('#tableDup').DataTable();


### PR DESCRIPTION
/!\ Merged with branch #160 to preemptively prevent merge-conflict

Possibility to see the *diff* between two pastes marked as duplicate.
The difference/webpage is computed/generated by the python module ```difflib```.
Solving #154 