### PR TITLE
Iss 169

### DIFF
--- a/bin/feeder/pystemon-feeder.py
+++ b/bin/feeder/pystemon-feeder.py
@@ -61,5 +61,8 @@ while True:
         continue
     socket.send("%d %s" % (topic, paste))
     topic = 102
-    messagedata = open(pystemonpath+paste).read()
-    socket.send("%d %s %s" % (topic, paste, base64.b64encode(messagedata)))
+    try:
+        messagedata = open(pystemonpath+paste).read()
+        socket.send("%d %s %s" % (topic, paste, base64.b64encode(messagedata)))
+    except IOError as e:
+        continue


### PR DESCRIPTION
Should fix issue #169

A buffering problem might happen in File ``pystemon-feeder.py``, in
```
messagedata = open(pystemonpath+paste).read()
-> IOError: [Errno 2] No such file or directory: *filename*
```
This could be because the *reader* (``pystemon-feeder``) is trying to read the file before it gets actually written on disk by the *writer* (``pystemon``).

To solve this problem, we added a simplistic back-off time similar to classical collision-avoidance algorithm.