### PR TITLE
fix: Create a directory for the last year

### DIFF
--- a/installing_deps.sh
+++ b/installing_deps.sh
@@ -89,8 +89,9 @@ if [ -z "$VIRTUAL_ENV" ]; then
 fi
 
 year1=20`date +%y`
+year2=20`date --date='-1 year' +%y`
 mkdir -p $AIL_HOME/{PASTES,Blooms,dumps}
-mkdir -p $AIL_HOME/LEVEL_DB_DATA/$year1
+mkdir -p $AIL_HOME/LEVEL_DB_DATA/{$year1,$year2}
 
 pip install -U pip
 pip install -U -r pip_packages_requirement.txt


### PR DESCRIPTION
Directories in LELVEL_DB_DATA are created when starting ``install_dependencies.sh``. If the range to check for duplicates exceed the current year AND the user as started the install script days later the new year, it might cause a ``ConnectionError``.
This fix creates a directory for the past year, to cover this case.