### PR TITLE
docker build fails on easy_install

### DIFF
--- a/installing_deps.sh
+++ b/installing_deps.sh
@@ -8,6 +8,9 @@ sudo apt-get update
 sudo apt-get install python3-pip python-virtualenv python3-dev libfreetype6-dev \
     screen g++ python-tk unzip libsnappy-dev cmake -y
 
+# required for easy_install
+python -m pip install -U setuptools
+
 #optional tor install
 sudo apt-get install tor -y
 


### PR DESCRIPTION
The docker build fails when easy_install is executed because the python setuptools are not installed.
So when i added 'python -m pip install -U setuptools'  the docker build continued.