### PR TITLE
Using pip3 instead of pip fixes docker issues

### DIFF
--- a/installing_deps.sh
+++ b/installing_deps.sh
@@ -27,7 +27,7 @@ sudo apt-get install libev-dev libgmp-dev -y
 sudo apt-get install graphviz -y
 
 # install nosetests
-sudo pip install nose
+sudo pip3 install nose
 
 # ssdeep
 sudo apt-get install libfuzzy-dev -y


### PR DESCRIPTION
Current docker deployment fails with:

```
$ docker build -t ail-framework .
[...]
+ sudo pip install nose
sudo: pip: command not found
The command '/bin/sh -c ./installing_deps.sh' returned a non-zero code: 1
```

This patch fixes this.