### PR TITLE
Fixes encoding issue with MISP Galaxies JSON files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,7 @@ WORKDIR /opt/AIL/var/www
 RUN ./update_thirdparty.sh
 WORKDIR /opt/AIL
 
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
 CMD bash docker_start.sh


### PR DESCRIPTION
After fixing #210, you get:

```
$ docker run -p 7000:7000 ail-framework
Misp not connected
The HIVE not connected
Traceback (most recent call last):
  File "Flask_server.py", line 66, in <module>
    importlib.import_module(name)
  File "/opt/AIL/AILENV/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 665, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "modules/Tags/Flask_Tags.py", line 34, in <module>
    clusters = Clusters(skip_duplicates=True)
  File "/opt/AIL/AILENV/lib/python3.5/site-packages/pymispgalaxies/api.py", line 267, in __init__
    clusters.append(json.load(f))
  File "/usr/lib/python3.5/json/__init__.py", line 265, in load
    return loads(fp.read(),
  File "/opt/AIL/AILENV/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1641: ordinal not in range(128)
```

The user under which everything runs doesn't have encoding set so python uses ascii by default but MISP Galaxies JSON files have UTF-8 in them...

This patch fixes this problem by setting an environment variables that tells python that UTF-8 is ok.
