### PR TITLE
[fix] switch from git:// to https:// while cloning tlsh.git

### DIFF
--- a/installing_deps.sh
+++ b/installing_deps.sh
@@ -55,7 +55,7 @@ sudo ldconfig
 popd
 
 # tlsh
-test ! -d tlsh && git clone git://github.com/trendmicro/tlsh.git
+test ! -d tlsh && git clone https://github.com/trendmicro/tlsh.git
 pushd tlsh/
 ./make.sh
 pushd build/release/


### PR DESCRIPTION
switch from git:// to https:// while cloning tlsh.git