### PR TITLE
README.md: Add note regarding Direct I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ linux based distributions, you can replace it with [installing_deps_archlinux.sh
 
 There is also a [Travis file](.travis.yml) used for automating the installation that can be used to build and install AIL on other systems.
 
+Installation Notes
+------------
+
+In order to use AIL combined with **ZFS** or **unprivileged LXC** it's necessary to disable Direct I/O in `$AIL_HOME/configs/6382.conf` by changing the value of the directive `use_direct_io_for_flush_and_compaction` to `false`.
+
 Python 3 Upgrade
 ------------
 


### PR DESCRIPTION
The introduction of `ardb-server` along with `rocksdb` resulted in using [direct I/O](https://github.com/facebook/rocksdb/wiki/Direct-IO). This is configured in the [corresponding configuration file](https://github.com/CIRCL/AIL-framework/blob/master/configs/6382.conf#L65).

Our tests suggested that direct I/O isn't guaranteed to be available on systems using ZFS (see [this issue](https://github.com/zfsonlinux/zfs/issues/224)) or unprivileged LXC containers. The `ardb-server` instance would crash on startup using the default configuration. Therefore it was necessary to disable this feature.

To save people from having to diagnose this, this PR adds a note regarding this issue in the `README.md` file.

Note: An easy way to check if direct I/O is available on a given host is to execute `dd oflag=direct if=/dev/zero of=/tmp/testfile bs=1M count=1` and checking the output for errors.