### PR TITLE
Term management upgrade

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -26,6 +26,24 @@ ARDB overview
 ARDB_DB
 * DB 1 - Curve
 * DB 2 - TermFreq
+	----------------------------------------- TERM ----------------------------------------
+
+	SET - 'TrackedRegexSet'				term
+
+	HSET - 'TrackedRegexDate'			tracked_regex		today_timestamp
+
+	SET - 'TrackedSetSet'				set_to_add
+
+	HSET - 'TrackedSetDate'				set_to_add		today_timestamp
+
+	SET - 'TrackedSetTermSet'			term
+
+	HSET - 'TrackedTermDate'			tracked_regex		today_timestamp
+
+	SET - 'TrackedNotificationEmails_'+term/set	email
+
+	SET - 'TrackedNotifications'			term/set
+
 * DB 3 - Trending
 * DB 4 - Sentiment
 * DB 5 - TermCred

--- a/bin/Curve.py
+++ b/bin/Curve.py
@@ -48,6 +48,8 @@ top_termFreq_setName_week = ["TopTermFreq_set_week", 7]
 top_termFreq_setName_month = ["TopTermFreq_set_month", 31]
 top_termFreq_set_array = [top_termFreq_setName_day,top_termFreq_setName_week, top_termFreq_setName_month]
 
+TrackedTermsNotificationTagsPrefix_Name = "TrackedNotificationTags_"
+
 # create direct link in mail
 full_paste_url = "/showsavedpaste/?paste="
 
@@ -70,6 +72,11 @@ def check_if_tracked_term(term, path):
             # Send to every associated email adress
             for email in server_term.smembers(TrackedTermsNotificationEmailsPrefix_Name + term):
                 sendEmailNotification(email, 'Term', mail_body)
+
+        # tag paste
+        for tag in server_term.smembers(TrackedTermsNotificationTagsPrefix_Name + term):
+            msg = '{};{}'.format(tag, path)
+            p.populate_set_out(msg, 'Tags')
 
 
 def getValueOverRange(word, startDate, num_day):

--- a/bin/RegexForTermsFrequency.py
+++ b/bin/RegexForTermsFrequency.py
@@ -42,6 +42,8 @@ top_termFreq_setName_week = ["TopTermFreq_set_week", 7]
 top_termFreq_setName_month = ["TopTermFreq_set_month", 31]
 top_termFreq_set_array = [top_termFreq_setName_day, top_termFreq_setName_week, top_termFreq_setName_month]
 
+TrackedTermsNotificationTagsPrefix_Name = "TrackedNotificationTags_"
+
 # create direct link in mail
 full_paste_url = "/showsavedpaste/?paste="
 
@@ -128,6 +130,11 @@ if __name__ == "__main__":
                             # Send to every associated email adress
                             for email in server_term.smembers(TrackedTermsNotificationEmailsPrefix_Name + regex_str_complete):
                                 sendEmailNotification(email, 'Term', mail_body)
+
+                        # tag paste
+                        for tag in server_term.smembers(TrackedTermsNotificationTagsPrefix_Name + regex_str_complete):
+                            msg = '{};{}'.format(tag, filename)
+                            p.populate_set_out(msg, 'Tags')
 
                         set_name = 'regex_' + dico_regexname_to_redis[regex_str]
                         new_to_the_set = server_term.sadd(set_name, filename)

--- a/bin/SetForTermsFrequency.py
+++ b/bin/SetForTermsFrequency.py
@@ -34,6 +34,8 @@ top_termFreq_setName_week = ["TopTermFreq_set_week", 7]
 top_termFreq_setName_month = ["TopTermFreq_set_month", 31]
 top_termFreq_set_array = [top_termFreq_setName_day,top_termFreq_setName_week, top_termFreq_setName_month]
 
+TrackedTermsNotificationTagsPrefix_Name = "TrackedNotificationTags_"
+
 # create direct link in mail
 full_paste_url = "/showsavedpaste/?paste="
 
@@ -120,6 +122,11 @@ if __name__ == "__main__":
                         # Send to every associated email adress
                         for email in server_term.smembers(TrackedTermsNotificationEmailsPrefix_Name + dico_setname_to_redis[str(the_set)]):
                             sendEmailNotification(email, 'Term', mail_body)
+
+                    # tag paste
+                    for tag in server_term.smembers(TrackedTermsNotificationTagsPrefix_Name + dico_setname_to_redis[str(the_set)]):
+                        msg = '{};{}'.format(tag, filename)
+                        p.populate_set_out(msg, 'Tags')
 
                     print(the_set, "matched in", filename)
                     set_name = 'set_' + dico_setname_to_redis[the_set]

--- a/bin/packages/modules.cfg
+++ b/bin/packages/modules.cfg
@@ -32,13 +32,15 @@ publish = Redis_Words
 
 [Curve]
 subscribe = Redis_Words
-publish = Redis_CurveManageTopSets
+publish = Redis_CurveManageTopSets,Redis_Tags
 
 [RegexForTermsFrequency]
 subscribe = Redis_Global
+publish = Redis_Tags
 
 [SetForTermsFrequency]
 subscribe = Redis_Global
+publish = Redis_Tags
 
 [CurveManageTopSets]
 subscribe = Redis_CurveManageTopSets

--- a/var/www/modules/Flask_config.py
+++ b/var/www/modules/Flask_config.py
@@ -102,7 +102,6 @@ r_serv_onion = redis.StrictRedis(
     db=cfg.getint("ARDB_Onion", "db"),
     decode_responses=True)
 
-
 sys.path.append('../../configs/keys')
 # MISP #
 try:

--- a/var/www/modules/PasteSubmit/Flask_PasteSubmit.py
+++ b/var/www/modules/PasteSubmit/Flask_PasteSubmit.py
@@ -605,6 +605,10 @@ def disable_hive_auto_alert():
 @PasteSubmit.route("/PasteSubmit/add_push_tag")
 def add_push_tag():
     tag = request.args.get('tag')
+    #limit tag length
+    if len(tag) > 49:
+        tag = tag[0:48]
+
     r_serv_db.sadd('list_export_tags', tag)
 
     to_return = {}

--- a/var/www/modules/PasteSubmit/Flask_PasteSubmit.py
+++ b/var/www/modules/PasteSubmit/Flask_PasteSubmit.py
@@ -602,6 +602,15 @@ def disable_hive_auto_alert():
     r_serv_db.set('hive:auto-alerts', 0)
     return edit_tag_export()
 
+@PasteSubmit.route("/PasteSubmit/add_push_tag")
+def add_push_tag():
+    tag = request.args.get('tag')
+    r_serv_db.sadd('list_export_tags', tag)
+
+    to_return = {}
+    to_return["tag"] = tag
+    return jsonify(to_return)
+
 @PasteSubmit.route("/PasteSubmit/delete_push_tag")
 def delete_push_tag():
     tag = request.args.get('tag')
@@ -609,7 +618,8 @@ def delete_push_tag():
     infoleak_tags = Taxonomies().get('infoleak').machinetags()
     if tag not in infoleak_tags and r_serv_db.sismember('list_export_tags', tag):
         r_serv_db.srem('list_export_tags', tag)
-        #print('deleted')
+        r_serv_db.srem('whitelist_misp', tag)
+        r_serv_db.srem('whitelist_hive', tag)
         to_return = {}
         to_return["tag"] = tag
         return jsonify(to_return)

--- a/var/www/modules/PasteSubmit/Flask_PasteSubmit.py
+++ b/var/www/modules/PasteSubmit/Flask_PasteSubmit.py
@@ -605,15 +605,19 @@ def disable_hive_auto_alert():
 @PasteSubmit.route("/PasteSubmit/add_push_tag")
 def add_push_tag():
     tag = request.args.get('tag')
-    #limit tag length
-    if len(tag) > 49:
-        tag = tag[0:48]
+    if tag is not None:
 
-    r_serv_db.sadd('list_export_tags', tag)
+        #limit tag length
+        if len(tag) > 49:
+            tag = tag[0:48]
 
-    to_return = {}
-    to_return["tag"] = tag
-    return jsonify(to_return)
+        r_serv_db.sadd('list_export_tags', tag)
+
+        to_return = {}
+        to_return["tag"] = tag
+        return jsonify(to_return)
+    else:
+        return 'None args', 400
 
 @PasteSubmit.route("/PasteSubmit/delete_push_tag")
 def delete_push_tag():

--- a/var/www/modules/PasteSubmit/Flask_PasteSubmit.py
+++ b/var/www/modules/PasteSubmit/Flask_PasteSubmit.py
@@ -506,6 +506,8 @@ def edit_tag_export():
     status_misp = []
     status_hive = []
 
+    infoleak_tags = Taxonomies().get('infoleak').machinetags()
+    is_infoleak_tag = []
 
     for tag in list_export_tags:
         if r_serv_db.sismember('whitelist_misp', tag):
@@ -518,6 +520,11 @@ def edit_tag_export():
             status_hive.append(True)
         else:
             status_hive.append(False)
+
+        if tag in infoleak_tags:
+            is_infoleak_tag.append(True)
+        else:
+            is_infoleak_tag.append(False)
 
     if misp_auto_events is not None:
         if int(misp_auto_events) == 1:
@@ -543,6 +550,7 @@ def edit_tag_export():
                             misp_active=misp_active,
                             hive_active=hive_active,
                             list_export_tags=list_export_tags,
+                            is_infoleak_tag=is_infoleak_tag,
                             status_misp=status_misp,
                             status_hive=status_hive,
                             nb_tags_whitelist_misp=nb_tags_whitelist_misp,
@@ -593,6 +601,20 @@ def enable_hive_auto_alert():
 def disable_hive_auto_alert():
     r_serv_db.set('hive:auto-alerts', 0)
     return edit_tag_export()
+
+@PasteSubmit.route("/PasteSubmit/delete_push_tag")
+def delete_push_tag():
+    tag = request.args.get('tag')
+
+    infoleak_tags = Taxonomies().get('infoleak').machinetags()
+    if tag not in infoleak_tags and r_serv_db.sismember('list_export_tags', tag):
+        r_serv_db.srem('list_export_tags', tag)
+        #print('deleted')
+        to_return = {}
+        to_return["tag"] = tag
+        return jsonify(to_return)
+    else:
+        return 'this tag can\'t be removed', 400
 
 # ========= REGISTRATION =========
 app.register_blueprint(PasteSubmit, url_prefix=baseUrl)

--- a/var/www/modules/PasteSubmit/templates/edit_tag_export.html
+++ b/var/www/modules/PasteSubmit/templates/edit_tag_export.html
@@ -219,7 +219,14 @@
 																<input type="checkbox" value="{{ tag }}" name="tag_enabled_hive" >
 															{% endif %}
 						                </td>
-														<td>{{ tag }}</td>
+														<td>
+															{{ tag }}
+															{% if not is_infoleak_tag[loop.index0] %}
+																<div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="tooltip" title="Delete this tag" onclick="delete_push_tag('{{ tag }}')">
+																	<span class="glyphicon glyphicon-trash"></span>
+																</div>
+															{% endif %}
+														</td>
 												</tr>
 											{%  endfor %}
 
@@ -241,6 +248,42 @@
 	      </div>
 
       </form>
+
+			<div>
+
+				<div id="add_custom_tag_modal" class="modal fade" role="dialog">
+					<div class="modal-dialog">
+
+						<!-- Modal content-->
+						<div id="mymodalcontent" class="modal-content">
+							<div class="modal-header" style="border-bottom: 4px solid #48c9b0; background-color: #48c9b0; color: #ffffff;">
+								<h2 class="text-center">Add Custom Tag</h2>
+
+							</div>
+
+							<div class="modal-body">
+								<div class="form-group input-group" style="margin-bottom: 0px;">
+                  <span class="input-group-addon"><i class="fa fa-tag fa"></i></span>
+                  <input id="new_custom_tag" class="form-control" placeholder="Add a new custom tag to the tag export" type="text">
+                </div>
+							</div>
+
+							<div class="modal-footer">
+								<button class="btn btn-primary btn-tags" onclick="add_custom_tag()">
+										<span class="glyphicon glyphicon-plus"></span>
+										<span class="label-icon">Add Custom Tag</span>
+								</button>
+								<button type="button" class="btn btn-default" data-dismiss="modal" >Close</button>
+
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<button type="button" class="btn btn-primary pull-right" data-toggle="modal" data-target="#add_custom_tag_modal" data-url="{{ url_for('Tags.taxonomies') }}">
+					<span class="glyphicon glyphicon-plus "></span> Add Custom Tag
+				</button>
+			</div>
 
       </div>
             <!-- /#page-wrapper -->
@@ -291,6 +334,15 @@ $(document).ready(function(){
 	function delete_push_tag(tag){
 		//var row_tr = $(this).closest("tr");
 		$.get("{{ url_for('PasteSubmit.delete_push_tag') }}", { tag: tag }, function(data, status){
+				if(status == "success") {
+						//row_tr.remove();
+						window.location.reload(false);
+				}
+		});
+	}
+
+	function add_custom_tag(){
+		$.get("{{ url_for('PasteSubmit.add_push_tag') }}", { tag: document.getElementById('new_custom_tag').value }, function(data, status){
 				if(status == "success") {
 						//row_tr.remove();
 						window.location.reload(false);

--- a/var/www/modules/PasteSubmit/templates/edit_tag_export.html
+++ b/var/www/modules/PasteSubmit/templates/edit_tag_export.html
@@ -37,6 +37,9 @@
 				background: #d91f2d;
 				color: #fff;
 			}
+			.mouse_pointer{
+				cursor: pointer;
+			}
 		</style>
 
 	</head>
@@ -169,7 +172,14 @@
 																<input type="checkbox" value="{{ tag }}" name="tag_enabled_misp" >
 															{% endif %}
 						                </td>
-														<td>{{ tag }}</td>
+														<td>
+															{{ tag }}
+															{% if not is_infoleak_tag[loop.index0] %}
+																<div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="tooltip" title="Delete this tag" onclick="delete_push_tag('{{ tag }}')">
+																	<span class="glyphicon glyphicon-trash"></span>
+																</div>
+															{% endif %}
+														</td>
 												</tr>
 											{%  endfor %}
 
@@ -277,6 +287,16 @@ $(document).ready(function(){
 			}
 		);
   }
+
+	function delete_push_tag(tag){
+		//var row_tr = $(this).closest("tr");
+		$.get("{{ url_for('PasteSubmit.delete_push_tag') }}", { tag: tag }, function(data, status){
+				if(status == "success") {
+						//row_tr.remove();
+						window.location.reload(false);
+				}
+		});
+	}
 </script>
 
 </html>

--- a/var/www/modules/terms/Flask_terms.py
+++ b/var/www/modules/terms/Flask_terms.py
@@ -169,7 +169,7 @@ def terms_management():
     trackReg_list_num_of_paste = []
     for tracked_regex in r_serv_term.smembers(TrackedRegexSet_Name):
 
-        notificationEMailTermMapping[tracked_regex] = "\n".join( (r_serv_term.smembers(TrackedTermsNotificationEmailsPrefix_Name + tracked_regex)) )
+        notificationEMailTermMapping[tracked_regex] = r_serv_term.smembers(TrackedTermsNotificationEmailsPrefix_Name + tracked_regex)
         notificationTagsTermMapping[tracked_regex] = r_serv_term.smembers(TrackedTermsNotificationTagsPrefix_Name + tracked_regex)
 
         if tracked_regex not in notificationEnabledDict:
@@ -196,7 +196,7 @@ def terms_management():
     for tracked_set in r_serv_term.smembers(TrackedSetSet_Name):
         tracked_set = tracked_set
 
-        notificationEMailTermMapping[tracked_set] = "\n".join( (r_serv_term.smembers(TrackedTermsNotificationEmailsPrefix_Name + tracked_set)) )
+        notificationEMailTermMapping[tracked_set] = r_serv_term.smembers(TrackedTermsNotificationEmailsPrefix_Name + tracked_set)
         notificationTagsTermMapping[tracked_set] = r_serv_term.smembers(TrackedTermsNotificationTagsPrefix_Name + tracked_set)
 
         if tracked_set not in notificationEnabledDict:
@@ -222,7 +222,7 @@ def terms_management():
     track_list_num_of_paste = []
     for tracked_term in r_serv_term.smembers(TrackedTermsSet_Name):
 
-        notificationEMailTermMapping[tracked_term] = "\n".join( r_serv_term.smembers(TrackedTermsNotificationEmailsPrefix_Name + tracked_term))
+        notificationEMailTermMapping[tracked_term] = r_serv_term.smembers(TrackedTermsNotificationEmailsPrefix_Name + tracked_term)
         notificationTagsTermMapping[tracked_term] = r_serv_term.smembers(TrackedTermsNotificationTagsPrefix_Name + tracked_term)
 
         if tracked_term not in notificationEnabledDict:
@@ -334,11 +334,8 @@ def terms_management_action():
         if section == "followTerm":
             if action == "add":
 
-                # Strip all whitespace
-                notificationEmailsParam = "".join(notificationEmailsParam.split())
-
                 # Make a list of all passed email addresses
-                notificationEmails = notificationEmailsParam.split(",")
+                notificationEmails = notificationEmailsParam.split()
 
                 validNotificationEmails = []
                 # check for valid email addresses
@@ -443,6 +440,16 @@ def terms_management_action():
         to_return["term"] = term
         return jsonify(to_return)
 
+@terms.route("/terms_management/delete_terms_email", methods=['GET'])
+def delete_terms_email():
+    term =  request.args.get('term')
+    email =  request.args.get('email')
+
+    if term is not None and email is not None:
+        r_serv_term.srem(TrackedTermsNotificationEmailsPrefix_Name + term, email)
+        return 'sucess'
+    else:
+        return 'None args', 400
 
 
 @terms.route("/terms_plot_tool/")

--- a/var/www/modules/terms/Flask_terms.py
+++ b/var/www/modules/terms/Flask_terms.py
@@ -24,6 +24,7 @@ cfg = Flask_config.cfg
 baseUrl = Flask_config.baseUrl
 r_serv_term = Flask_config.r_serv_term
 r_serv_cred = Flask_config.r_serv_cred
+r_serv_db = Flask_config.r_serv_db
 bootstrap_label = Flask_config.bootstrap_label
 
 terms = Blueprint('terms', __name__, template_folder='templates')
@@ -132,6 +133,9 @@ def mixUserName(supplied, extensive=False):
             filtered_usernames.append(usr)
     return filtered_usernames
 
+def save_tag_to_auto_push(list_tag):
+    for tag in set(list_tag):
+        r_serv_db.sadd('list_export_tags', tag)
 
 # ============ ROUTES ============
 
@@ -244,7 +248,6 @@ def terms_management():
         term_date = datetime.datetime.utcfromtimestamp(int(term_date)) if term_date is not None else "No date recorded"
         black_list.append([blacked_term, term_date])
 
-    print(notificationTagsTermMapping)
     return render_template("terms_management.html",
             black_list=black_list, track_list=track_list, trackReg_list=trackReg_list, trackSet_list=trackSet_list,
             track_list_values=track_list_values, track_list_num_of_paste=track_list_num_of_paste,
@@ -358,6 +361,7 @@ def terms_management_action():
                     # add tags list
                     for tag in list_tags:
                         r_serv_term.sadd(TrackedTermsNotificationTagsPrefix_Name + term, tag)
+                    save_tag_to_auto_push(list_tags)
 
                 #set
                 elif term.startswith('\\') and term.endswith('\\'):
@@ -379,6 +383,7 @@ def terms_management_action():
                     # add tags list
                     for tag in list_tags:
                         r_serv_term.sadd(TrackedTermsNotificationTagsPrefix_Name + set_to_add, tag)
+                    save_tag_to_auto_push(list_tags)
 
                 #simple term
                 else:
@@ -392,6 +397,7 @@ def terms_management_action():
                     # add tags list
                     for tag in list_tags:
                         r_serv_term.sadd(TrackedTermsNotificationTagsPrefix_Name + term.lower(), tag)
+                    save_tag_to_auto_push(list_tags)
 
             elif action == "toggleEMailNotification":
                 # get the current state

--- a/var/www/modules/terms/Flask_terms.py
+++ b/var/www/modules/terms/Flask_terms.py
@@ -135,6 +135,9 @@ def mixUserName(supplied, extensive=False):
 
 def save_tag_to_auto_push(list_tag):
     for tag in set(list_tag):
+        #limit tag length
+        if len(tag) > 49:
+            tag = tag[0:48]
         r_serv_db.sadd('list_export_tags', tag)
 
 # ============ ROUTES ============

--- a/var/www/modules/terms/Flask_terms.py
+++ b/var/www/modules/terms/Flask_terms.py
@@ -459,7 +459,7 @@ def delete_terms_email():
 
     if term is not None and email is not None:
         r_serv_term.srem(TrackedTermsNotificationEmailsPrefix_Name + term, email)
-        return 'sucess'
+        return redirect(url_for('terms.terms_management'))
     else:
         return 'None args', 400
 

--- a/var/www/modules/terms/Flask_terms.py
+++ b/var/www/modules/terms/Flask_terms.py
@@ -10,7 +10,7 @@ import redis
 import datetime
 import calendar
 import flask
-from flask import Flask, render_template, jsonify, request, Blueprint
+from flask import Flask, render_template, jsonify, request, Blueprint, url_for, redirect
 import re
 import Paste
 from pprint import pprint
@@ -439,6 +439,18 @@ def terms_management_action():
         to_return["action"] = action
         to_return["term"] = term
         return jsonify(to_return)
+
+@terms.route("/terms_management/delete_terms_tags", methods=['POST'])
+def delete_terms_tags():
+    term = request.form.get('term')
+    tags_to_delete = request.form.getlist('tags_to_delete')
+
+    if term is not None and tags_to_delete is not None:
+        for tag in tags_to_delete:
+            r_serv_term.srem(TrackedTermsNotificationTagsPrefix_Name + term, tag)
+        return redirect(url_for('terms.terms_management'))
+    else:
+        return 'None args', 400
 
 @terms.route("/terms_management/delete_terms_email", methods=['GET'])
 def delete_terms_email():

--- a/var/www/modules/terms/templates/terms_management.html
+++ b/var/www/modules/terms/templates/terms_management.html
@@ -39,6 +39,9 @@
       .mouse_pointer{
 				cursor: pointer;
 			}
+      .lb-md {
+        font-size: 16px;
+      }
   </style>
 </head>
 <body>
@@ -77,6 +80,7 @@
     <div class="row">
         <div class="col-lg-12">
             <div class="row">
+              {% set uniq_id = 0 %}
                 <div class="col-lg-12">
                    <label class="switch">
                        <input id="per_paste" class="switch-input" value="per_paste" type="checkbox" onclick="reload_per_paste()">
@@ -131,6 +135,47 @@
                                               <span class="label label-{{ bootstrap_label[loop.index0 % 5] }} pull-left">{{ tag }}</span>
                                             </a>
                                             {%  endfor %}
+                                            {% if notificationTagsTermMapping[set] %}
+                                              <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="modal" data-target="#edit_custom_tag_modal_{{ uniq_id }}" data-placement="right" title="Edit Tags List"><i class="fa fa-pencil" style="color:Red;"></i></div>
+
+                                              <div id="edit_custom_tag_modal_{{ uniq_id }}" class="modal fade" role="dialog">
+                                      					<div class="modal-dialog">
+
+                                      						<!-- Modal content-->
+                                      						<div id="mymodalcontent" class="modal-content">
+                                      							<div class="modal-header" style="border-bottom: 4px solid #48c9b0; background-color: #48c9b0; color: #ffffff;">
+                                      								<h2 class="text-center">Remove Custom Tag</h2>
+
+                                      							</div>
+
+                                      							<div class="modal-body">
+                                                      <form action="{{ url_for('terms.delete_terms_tags') }}" id="checkboxForm" method='post'>
+                                                        {% for tag in notificationTagsTermMapping[set] %}
+                                                          <div class="form-check">
+                                                             <input type="hidden" class="form-control" name="term" value="{{ set }}">
+                                                            <input type="checkbox" class="form-check-input" name="tags_to_delete" value="{{ tag }}">
+                                                            <label class="form-check-label">
+                                                              <span class="label label-{{ bootstrap_label[loop.index0 % 5] }} lb-md">{{ tag }}</span>
+                                                            </label>
+                                                            <br>
+                                                          </div>
+                                                        {%  endfor %}
+                                                      </form>
+                                      							</div>
+
+                                      							<div class="modal-footer">
+                                      								<button class="btn btn-danger" type="submit" form="checkboxForm" value="Submit">
+                                      										<span class="glyphicon glyphicon-trash"></span>
+                                      										<span class="label-icon">Remove Tags</span>
+                                      								</button>
+                                      								<button type="button" class="btn btn-default" data-dismiss="modal" >Close</button>
+
+                                      							</div>
+                                      						</div>
+                                      					</div>
+                                      				</div>
+                                              {% set uniq_id = uniq_id + 1 %}
+                                            {%  endif %}
                                           </div>
                                       </td>
                                       <td>{{ trackSet_list_values[loop.index0][3] }}</td>
@@ -163,6 +208,47 @@
                                               <span class="label label-{{ bootstrap_label[loop.index0 % 5] }} pull-left">{{ tag }}</span>
                                             </a>
                                             {%  endfor %}
+                                            {% if notificationTagsTermMapping[regex] %}
+                                              <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="modal" data-target="#edit_custom_tag_modal_{{ uniq_id }}" data-placement="right" title="Edit Tags List"><i class="fa fa-pencil" style="color:Red;"></i></div>
+
+                                              <div id="edit_custom_tag_modal_{{ uniq_id }}" class="modal fade" role="dialog">
+                                      					<div class="modal-dialog">
+
+                                      						<!-- Modal content-->
+                                      						<div id="mymodalcontent" class="modal-content">
+                                      							<div class="modal-header" style="border-bottom: 4px solid #48c9b0; background-color: #48c9b0; color: #ffffff;">
+                                      								<h2 class="text-center">Remove Custom Tag</h2>
+
+                                      							</div>
+
+                                      							<div class="modal-body">
+                                                      <form action="{{ url_for('terms.delete_terms_tags') }}" id="checkboxForm" method='post'>
+                                                        {% for tag in notificationTagsTermMapping[regex] %}
+                                                          <div class="form-check">
+                                                             <input type="hidden" class="form-control" name="term" value="{{ regex }}">
+                                                            <input type="checkbox" class="form-check-input" name="tags_to_delete" value="{{ tag }}">
+                                                            <label class="form-check-label">
+                                                              <span class="label label-{{ bootstrap_label[loop.index0 % 5] }} lb-md">{{ tag }}</span>
+                                                            </label>
+                                                            <br>
+                                                          </div>
+                                                        {%  endfor %}
+                                                      </form>
+                                      							</div>
+
+                                      							<div class="modal-footer">
+                                      								<button class="btn btn-danger" type="submit" form="checkboxForm" value="Submit">
+                                      										<span class="glyphicon glyphicon-trash"></span>
+                                      										<span class="label-icon">Remove Tags</span>
+                                      								</button>
+                                      								<button type="button" class="btn btn-default" data-dismiss="modal" >Close</button>
+
+                                      							</div>
+                                      						</div>
+                                      					</div>
+                                      				</div>
+                                              {% set uniq_id = uniq_id + 1 %}
+                                            {%  endif %}
                                           </div>
                                       </td>
                                       <td>{{ trackReg_list_values[loop.index0][3] }}</td>
@@ -195,6 +281,47 @@
                                               <span class="label label-{{ bootstrap_label[loop.index0 % 5] }} pull-left">{{ tag }}</span>
                                             </a>
                                             {%  endfor %}
+                                            {% if notificationTagsTermMapping[term] %}
+                                              <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="modal" data-target="#edit_custom_tag_modal_{{ uniq_id }}" data-placement="right" title="Edit Tags List"><i class="fa fa-pencil" style="color:Red;"></i></div>
+
+                                              <div id="edit_custom_tag_modal_{{ uniq_id }}" class="modal fade" role="dialog">
+                                      					<div class="modal-dialog">
+
+                                      						<!-- Modal content-->
+                                      						<div id="mymodalcontent" class="modal-content">
+                                      							<div class="modal-header" style="border-bottom: 4px solid #48c9b0; background-color: #48c9b0; color: #ffffff;">
+                                      								<h2 class="text-center">Remove Custom Tag</h2>
+
+                                      							</div>
+
+                                      							<div class="modal-body">
+                                                      <form action="{{ url_for('terms.delete_terms_tags') }}" id="checkboxForm" method='post'>
+                                                        {% for tag in notificationTagsTermMapping[term] %}
+                                                          <div class="form-check">
+                                                             <input type="hidden" class="form-control" name="term" value="{{ term }}">
+                                                            <input type="checkbox" class="form-check-input" name="tags_to_delete" value="{{ tag }}">
+                                                            <label class="form-check-label">
+                                                              <span class="label label-{{ bootstrap_label[loop.index0 % 5] }} lb-md">{{ tag }}</span>
+                                                            </label>
+                                                            <br>
+                                                          </div>
+                                                        {%  endfor %}
+                                                      </form>
+                                      							</div>
+
+                                      							<div class="modal-footer">
+                                      								<button class="btn btn-danger" type="submit" form="checkboxForm" value="Submit">
+                                      										<span class="glyphicon glyphicon-trash"></span>
+                                      										<span class="label-icon">Remove Tags</span>
+                                      								</button>
+                                      								<button type="button" class="btn btn-default" data-dismiss="modal" >Close</button>
+
+                                      							</div>
+                                      						</div>
+                                      					</div>
+                                      				</div>
+                                              {% set uniq_id = uniq_id + 1 %}
+                                            {%  endif %}
                                           </div>
                                       </td>
                                       <td>{{ track_list_values[loop.index0][3] }}</td>

--- a/var/www/modules/terms/templates/terms_management.html
+++ b/var/www/modules/terms/templates/terms_management.html
@@ -98,7 +98,8 @@
                             <div class="form-group input-group" style="margin-bottom: 30px;">
                                 <span class="input-group-addon"><span class="fa fa-eye"></span></span>
                                 <input id="followTermInput" class="form-control" placeholder="Term to track." type="text" style="max-width: 400px;">
-                                <input id="followTermEMailNotificationReceiversInput" class="form-control" placeholder="Notification E-Mails (comma separated)" type="text" style="max-width: 400px;">
+                                <input id="followTermEMailNotificationReceiversInput" class="form-control" placeholder="Notification E-Mails (optional, comma separated)" type="text" style="max-width: 400px;">
+                                <input id="followTermTag" class="form-control" placeholder="Tags (optional, space separated)" type="text" style="max-width: 400px;">
                                 <button id="followTermBtn" class="btn btn-success btn-interaction" style="margin-left: 10px;" data-section="followTerm" data-action="add"> Add term</button>
                             </div>
 
@@ -119,7 +120,16 @@
                                 <!-- SET -->
                                 {% for set in trackSet_list %}
                                   <tr style="background-color: #cdffca;">
-                                      <td>{{ set }}</td>
+                                      <td>
+                                          <span class="term_name">{{ set }}</span>
+                                          <div>
+                                            {% for tag in notificationTagsTermMapping[set] %}
+                                            <a href="{{ url_for('Tags.get_tagged_paste') }}?ltags={{ tag }}">
+                                              <span class="label label-{{ bootstrap_label[loop.index0 % 5] }} pull-left">{{ tag }}</span>
+                                            </a>
+                                            {%  endfor %}
+                                          </div>
+                                      </td>
                                       <td>{{ trackSet_list_values[loop.index0][3] }}</td>
                                       <td>{{ trackSet_list_values[loop.index0][0] }}</td>
                                       <td>{{ trackSet_list_values[loop.index0][1] }}</td>
@@ -136,7 +146,16 @@
                                 <!-- REGEX -->
                                 {% for regex in trackReg_list %}
                                   <tr style="background-color: #fffdca;">
-                                      <td>{{ regex }}</td>
+                                      <td>
+                                          <span class="term_name">{{ regex }}</span>
+                                          <div>
+                                            {% for tag in notificationTagsTermMapping[regex] %}
+                                            <a href="{{ url_for('Tags.get_tagged_paste') }}?ltags={{ tag }}">
+                                              <span class="label label-{{ bootstrap_label[loop.index0 % 5] }} pull-left">{{ tag }}</span>
+                                            </a>
+                                            {%  endfor %}
+                                          </div>
+                                      </td>
                                       <td>{{ trackReg_list_values[loop.index0][3] }}</td>
                                       <td>{{ trackReg_list_values[loop.index0][0] }}</td>
                                       <td>{{ trackReg_list_values[loop.index0][1] }}</td>
@@ -153,7 +172,16 @@
                                 <!-- Normal term -->
                                 {% for term in track_list %}
                                   <tr>
-                                      <td>{{ term }}</td>
+                                      <td>
+                                          <span class="term_name">{{ term }}</span>
+                                          <div>
+                                            {% for tag in notificationTagsTermMapping[term] %}
+                                            <a href="{{ url_for('Tags.get_tagged_paste') }}?ltags={{ tag }}">
+                                              <span class="label label-{{ bootstrap_label[loop.index0 % 5] }} pull-left">{{ tag }}</span>
+                                            </a>
+                                            {%  endfor %}
+                                          </div>
+                                      </td>
                                       <td>{{ track_list_values[loop.index0][3] }}</td>
                                       <td>{{ track_list_values[loop.index0][0] }}</td>
                                       <td>{{ track_list_values[loop.index0][1] }}</td>
@@ -351,17 +379,19 @@ function perform_binding() {
 function perform_operation(){
     var curr_section = $(this).attr('data-section');
     var curr_action = $(this).attr('data-action');
+    var row_tr = $(this).closest("tr");
     if (curr_action == "add") {
         var curr_term = $('#'+curr_section+'Input').val();
         var email_addresses = $('#followTermEMailNotificationReceiversInput').val();
+        var tags = $('#followTermTag').val();
     } else {
         var curr_term = $(this).attr('data-content');
         var email_addresses = "";
     }
-    var data_to_send = { section: curr_section, action: curr_action, term: curr_term, emailAddresses: email_addresses};
+    var data_to_send = { section: curr_section, action: curr_action, term: curr_term, emailAddresses: email_addresses, tags: tags};
 
     if (curr_term != "") {
-        console.log(data_to_send);
+        //console.log(data_to_send);
         $.get("{{ url_for('terms.terms_management_action') }}", data_to_send, function(data, status){
             if(status == "success") {
                 var json = data;
@@ -372,13 +402,8 @@ function perform_operation(){
                         $.get("{{ url_for('terms.terms_management_query') }}", { term: json.term, section: json.section }, function(data2, status){
                             reload_per_paste();
                         });
-                   } else if (json.action == "delete") {
-                       // Find indexes of row which have the term in the first column
-                       var index = table_track.rows().eq( 0 ).filter( function (rowIdx) {
-                           console.log(table_track.cell( rowIdx, 0 ).data())
-                           return table_track.cell( rowIdx, 0 ).data() === json.term;
-                       } );
-                       table_track.rows(index).remove().draw( false );
+                    } else if (json.action == "delete") {
+                      row_tr.remove()
                     }
                 } else if(json.section == "blacklistTerm"){
                     if(json.action == "add") {

--- a/var/www/modules/terms/templates/terms_management.html
+++ b/var/www/modules/terms/templates/terms_management.html
@@ -190,7 +190,11 @@
                                       </p></td>
                                       <td>
                                         {% for email in notificationEMailTermMapping[set] %}
-                                          <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="tooltip" data-placement="left" data-original-title="Remove this email"><span class="glyphicon glyphicon-trash" style="color:Red;" onclick="delete_email('{{set}}', '{{email}}')"></span></div>
+                                          <a href="{{ url_for('terms.delete_terms_email') }}?email={{email}}&term={{set}}">
+                                            <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="tooltip" data-placement="left" data-original-title="Remove this email">
+                                                <span class="glyphicon glyphicon-trash" style="color:Red;" ></span>
+                                            </div>
+                                          </a>
                                           {{ email }}
                                           <br>
                                         {%  endfor %}
@@ -263,7 +267,11 @@
                                       </p></td>
                                       <td>
                                         {% for email in notificationEMailTermMapping[regex] %}
-                                          <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="tooltip" data-placement="left" data-original-title="Remove this email"><span class="glyphicon glyphicon-trash" style="color:Red;" onclick="delete_email('{{regex}}', '{{email}}')"></span></div>
+                                          <a href="{{ url_for('terms.delete_terms_email') }}?email={{email}}&term={{regex}}">
+                                            <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="tooltip" data-placement="left" data-original-title="Remove this email">
+                                              <span class="glyphicon glyphicon-trash" style="color:Red;"></span>
+                                            </div>
+                                          </a>
                                           {{ email }}
                                           <br>
                                         {%  endfor %}
@@ -336,7 +344,11 @@
                                       </p></td>
                                       <td>
                                         {% for email in notificationEMailTermMapping[term] %}
-                                          <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="tooltip" data-placement="left" data-original-title="Remove this email"><span class="glyphicon glyphicon-trash" style="color:Red;" onclick="delete_email('{{term}}', '{{email}}')"></span></div>
+                                          <a href="{{ url_for('terms.delete_terms_email') }}?email={{email}}&term={{term}}">
+                                            <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="tooltip" data-placement="left" data-original-title="Remove this email">
+                                                <span class="glyphicon glyphicon-trash" style="color:Red;"></span>
+                                            </div>
+                                          </a>
                                           {{ email }}
                                           <br>
                                         {%  endfor %}
@@ -575,13 +587,5 @@ function perform_operation(){
             }
         });
     }
-}
-
-function delete_email(term, email){
-  $.get("{{ url_for('terms.delete_terms_email') }}", { term: term, email: email }, function(data, status){
-      if(status == "success") {
-          window.location.reload(false);
-      }
-  });
 }
 </script>

--- a/var/www/modules/terms/templates/terms_management.html
+++ b/var/www/modules/terms/templates/terms_management.html
@@ -80,7 +80,7 @@
     <div class="row">
         <div class="col-lg-12">
             <div class="row">
-              {% set uniq_id = 0 %}
+              {% set uniq_id = namespace(modal_id=0)%}
                 <div class="col-lg-12">
                    <label class="switch">
                        <input id="per_paste" class="switch-input" value="per_paste" type="checkbox" onclick="reload_per_paste()">
@@ -136,9 +136,9 @@
                                             </a>
                                             {%  endfor %}
                                             {% if notificationTagsTermMapping[set] %}
-                                              <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="modal" data-target="#edit_custom_tag_modal_{{ uniq_id }}" data-placement="right" title="Edit Tags List"><i class="fa fa-pencil" style="color:Red;"></i></div>
+                                              <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="modal" data-target="#edit_custom_tag_modal_{{ uniq_id.modal_id }}" data-placement="right" title="Edit Tags List"><i class="fa fa-pencil" style="color:Red;"></i></div>
 
-                                              <div id="edit_custom_tag_modal_{{ uniq_id }}" class="modal fade" role="dialog">
+                                              <div id="edit_custom_tag_modal_{{ uniq_id.modal_id }}" class="modal fade" role="dialog">
                                       					<div class="modal-dialog">
 
                                       						<!-- Modal content-->
@@ -174,7 +174,7 @@
                                       						</div>
                                       					</div>
                                       				</div>
-                                              {% set uniq_id = uniq_id + 1 %}
+                                              {% set uniq_id.modal_id = uniq_id.modal_id + 1 %}
                                             {%  endif %}
                                           </div>
                                       </td>
@@ -213,9 +213,9 @@
                                             </a>
                                             {%  endfor %}
                                             {% if notificationTagsTermMapping[regex] %}
-                                              <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="modal" data-target="#edit_custom_tag_modal_{{ uniq_id }}" data-placement="right" title="Edit Tags List"><i class="fa fa-pencil" style="color:Red;"></i></div>
+                                              <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="modal" data-target="#edit_custom_tag_modal_{{ uniq_id.modal_id }}" data-placement="right" title="Edit Tags List"><i class="fa fa-pencil" style="color:Red;"></i></div>
 
-                                              <div id="edit_custom_tag_modal_{{ uniq_id }}" class="modal fade" role="dialog">
+                                              <div id="edit_custom_tag_modal_{{ uniq_id.modal_id }}" class="modal fade" role="dialog">
                                       					<div class="modal-dialog">
 
                                       						<!-- Modal content-->
@@ -251,7 +251,7 @@
                                       						</div>
                                       					</div>
                                       				</div>
-                                              {% set uniq_id = uniq_id + 1 %}
+                                              {% set uniq_id.modal_id = uniq_id.modal_id + 1 %}
                                             {%  endif %}
                                           </div>
                                       </td>
@@ -290,9 +290,9 @@
                                             </a>
                                             {%  endfor %}
                                             {% if notificationTagsTermMapping[term] %}
-                                              <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="modal" data-target="#edit_custom_tag_modal_{{ uniq_id }}" data-placement="right" title="Edit Tags List"><i class="fa fa-pencil" style="color:Red;"></i></div>
+                                              <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="modal" data-target="#edit_custom_tag_modal_{{ uniq_id.modal_id }}" data-placement="right" title="Edit Tags List"><i class="fa fa-pencil" style="color:Red;"></i></div>
 
-                                              <div id="edit_custom_tag_modal_{{ uniq_id }}" class="modal fade" role="dialog">
+                                              <div id="edit_custom_tag_modal_{{ uniq_id.modal_id }}" class="modal fade" role="dialog">
                                       					<div class="modal-dialog">
 
                                       						<!-- Modal content-->
@@ -328,7 +328,7 @@
                                       						</div>
                                       					</div>
                                       				</div>
-                                              {% set uniq_id = uniq_id + 1 %}
+                                              {% set uniq_id.modal_id = uniq_id.modal_id + 1 %}
                                             {%  endif %}
                                           </div>
                                       </td>

--- a/var/www/modules/terms/templates/terms_management.html
+++ b/var/www/modules/terms/templates/terms_management.html
@@ -36,6 +36,9 @@
          white-space:pre-wrap;
          word-wrap:break-word;
       }
+      .mouse_pointer{
+				cursor: pointer;
+			}
   </style>
 </head>
 <body>
@@ -98,7 +101,7 @@
                             <div class="form-group input-group" style="margin-bottom: 30px;">
                                 <span class="input-group-addon"><span class="fa fa-eye"></span></span>
                                 <input id="followTermInput" class="form-control" placeholder="Term to track." type="text" style="max-width: 400px;">
-                                <input id="followTermEMailNotificationReceiversInput" class="form-control" placeholder="Notification E-Mails (optional, comma separated)" type="text" style="max-width: 400px;">
+                                <input id="followTermEMailNotificationReceiversInput" class="form-control" placeholder="Notification E-Mails (optional, space separated)" type="text" style="max-width: 400px;">
                                 <input id="followTermTag" class="form-control" placeholder="Tags (optional, space separated)" type="text" style="max-width: 400px;">
                                 <button id="followTermBtn" class="btn btn-success btn-interaction" style="margin-left: 10px;" data-section="followTerm" data-action="add"> Add term</button>
                             </div>
@@ -140,7 +143,13 @@
                                           <button class="btn-link btn-interaction" data-toggle="tooltip" data-placement="left" title="Remove this term" data-content="{{ set }}" data-section="followTerm" data-action="delete"><span class="glyphicon glyphicon-trash"></span></button>
                                           &nbsp; &nbsp;<input id="checkBoxEMailAlerts" type="checkbox" title="Toggle E-Mail notifications" class="btn-link btn-interaction" data-content="{{ set }}" data-section="followTerm" data-action="toggleEMailNotification" {% if notificationEnabledDict[set] %} checked {% endif %}>
                                       </p></td>
-                                      <td style="white-space:pre">{{ notificationEMailTermMapping[set] }}</td>
+                                      <td>
+                                        {% for email in notificationEMailTermMapping[set] %}
+                                          <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="tooltip" data-placement="left" data-original-title="Remove this email"><span class="glyphicon glyphicon-trash" style="color:Red;" onclick="delete_email('{{set}}', '{{email}}')"></span></div>
+                                          {{ email }}
+                                          <br>
+                                        {%  endfor %}
+                                      </td>
                                   </tr>
                                 {% endfor %}
                                 <!-- REGEX -->
@@ -166,7 +175,13 @@
                                           <button class="btn-link btn-interaction" data-toggle="tooltip" data-placement="left" title="Remove this term" data-content="{{ regex }}" data-section="followTerm" data-action="delete"><span class="glyphicon glyphicon-trash"></span></button>
                                           &nbsp; &nbsp;<input id="checkBoxEMailAlerts" type="checkbox" title="Toggle E-Mail notifications" class="btn-link btn-interaction" data-content="{{ regex }}" data-section="followTerm" data-action="toggleEMailNotification" {% if notificationEnabledDict[regex] %} checked {% endif %}>
                                       </p></td>
-                                      <td style="white-space:pre">{{ notificationEMailTermMapping[regex] }}</td>
+                                      <td>
+                                        {% for email in notificationEMailTermMapping[regex] %}
+                                          <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="tooltip" data-placement="left" data-original-title="Remove this email"><span class="glyphicon glyphicon-trash" style="color:Red;" onclick="delete_email('{{regex}}', '{{email}}')"></span></div>
+                                          {{ email }}
+                                          <br>
+                                        {%  endfor %}
+                                      </td>
                                   </tr>
                                 {% endfor %}
                                 <!-- Normal term -->
@@ -192,7 +207,13 @@
                                           <button class="btn-link btn-interaction" data-toggle="tooltip" data-placement="left" title="Remove this term" data-content="{{ term }}" data-section="followTerm" data-action="delete"><span class="glyphicon glyphicon-trash"></span></button>
                                           &nbsp; &nbsp;<input id="checkBoxEMailAlerts" type="checkbox" title="Toggle E-Mail notifications" class="btn-link btn-interaction" data-content="{{ term }}" data-section="followTerm" data-action="toggleEMailNotification" {% if notificationEnabledDict[term] %} checked {% endif %}>
                                       </p></td>
-                                      <td style="white-space:pre">{{ notificationEMailTermMapping[term] }}</td>
+                                      <td>
+                                        {% for email in notificationEMailTermMapping[term] %}
+                                          <div class="btn-link btn-interaction pull-right mouse_pointer" data-toggle="tooltip" data-placement="left" data-original-title="Remove this email"><span class="glyphicon glyphicon-trash" style="color:Red;" onclick="delete_email('{{term}}', '{{email}}')"></span></div>
+                                          {{ email }}
+                                          <br>
+                                        {%  endfor %}
+                                      </td>
                                   </tr>
                                 {% endfor %}
                                 </tbody>
@@ -427,5 +448,13 @@ function perform_operation(){
             }
         });
     }
+}
+
+function delete_email(term, email){
+  $.get("{{ url_for('terms.delete_terms_email') }}", { term: term, email: email }, function(data, status){
+      if(status == "success") {
+          window.location.reload(false);
+      }
+  });
 }
 </script>


### PR DESCRIPTION
## Fix part of #274 and add content based on PR #283  

- Add [custom] tag when keyword is matching (e.g. different constituencies)
- Add MISP and TheHive interface to push when a term is matching
- Update/Remove terms' tags and emails

![image](https://user-images.githubusercontent.com/8857208/48200056-46429600-e35e-11e8-9aba-0e62f30ace45.png)

![image](https://user-images.githubusercontent.com/8857208/48200030-2f03a880-e35e-11e8-9c50-112f5935d1cb.png)

![image](https://user-images.githubusercontent.com/8857208/48200098-6c683600-e35e-11e8-9a9b-e837525636cb.png)

