### PR TITLE
add slash at AIL_HOME end

### DIFF
--- a/installing_deps.sh
+++ b/installing_deps.sh
@@ -78,7 +78,7 @@ if [ -z "$VIRTUAL_ENV" ]; then
 
     virtualenv -p python3 AILENV
 
-    echo export AIL_HOME=$(pwd) >> ./AILENV/bin/activate
+    echo export AIL_HOME=$(pwd)/ >> ./AILENV/bin/activate
     echo export AIL_BIN=$(pwd)/bin/ >> ./AILENV/bin/activate
     echo export AIL_FLASK=$(pwd)/var/www/ >> ./AILENV/bin/activate
     echo export AIL_REDIS=$(pwd)/redis/src/ >> ./AILENV/bin/activate


### PR DESCRIPTION
to avoid paths concatenation issues in several scripts like:
Helper.py at line 168 : dir_name = os.environ['AIL_HOME']+self.config.get('Directories', 'pastes')
pystemon-feeder.py at line 48 : pastes_directory = os.path.join(os.environ['AIL_HOME'], pastes_directory)