### PR TITLE
6381 - by default just listen on loopback interface [security hardening]

### DIFF
--- a/configs/6381.conf
+++ b/configs/6381.conf
@@ -61,7 +61,7 @@ tcp-backlog 511
 # Examples:
 #
 # bind 192.168.1.100 10.0.0.1
-# bind 127.0.0.1
+bind 127.0.0.1
 
 # Specify the path for the Unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen


### PR DESCRIPTION
user will change explicitly the bind option if necessary