### PR TITLE
6379 - by default just listen on loopback interface [security hardening]

### DIFF
--- a/configs/6379.conf
+++ b/configs/6379.conf
@@ -61,7 +61,7 @@ tcp-backlog 511
 # Examples:
 #
 # bind 192.168.1.100 10.0.0.1
-# bind 127.0.0.1
+bind 127.0.0.1
 
 # Specify the path for the Unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen
@@ -85,7 +85,7 @@ timeout 0
 # On Linux, the specified value (in seconds) is the period used to send ACKs.
 # Note that to close the connection the double of the time is needed.
 # On other kernels the period depends on the kernel configuration.
-#
+#s
 # A reasonable value for this option is 60 seconds.
 tcp-keepalive 0
 


### PR DESCRIPTION
user will change explicitly the bind option if necessary