### PR TITLE
Add pybgpranking to install deps

### DIFF
--- a/installing_deps.sh
+++ b/installing_deps.sh
@@ -95,6 +95,7 @@ popd
 mkdir -p $AIL_HOME/PASTES
 
 pip3 install -U pip
+pip3 install 'git+https://github.com/D4-project/BGP-Ranking.git/@7e698f87366e6f99b4d0d11852737db28e3ddc62#egg=pybgpranking&subdirectory=client'
 pip3 install -U -r pip3_packages_requirement.txt
 
 # Pyfaup


### PR DESCRIPTION
The python module DomainClassifier requires pybgpranking which is not
available in the community PyPI repository. This commit installs pybgpranking
from git using the same version required by DomainClassifier https://github.com/adulau/DomainClassifier

Fixes the following installation error when using installing_deps.sh:
```
Could not find a version that satisfies the requirement pybgpranking (from DomainClassifier->-r pip3_packages_requirement.txt (line 50)) (from versions: )
No matching distribution found for pybgpranking (from DomainClassifier->-r pip3_packages_requirement.txt (line 50))
```