### PR TITLE
Added support for username as notification credentials

### DIFF
--- a/bin/NotificationHelper.py
+++ b/bin/NotificationHelper.py
@@ -26,6 +26,7 @@ publisher.channel = "Script"
 def sendEmailNotification(recipient, alert_name, content):
 
     sender = config_loader.get_config_str("Notifications", "sender")
+    sender_user = config_loader.get_config_str("Notifications", "sender_user")
     sender_host = config_loader.get_config_str("Notifications", "sender_host")
     sender_port = config_loader.get_config_int("Notifications", "sender_port")
     sender_pw = config_loader.get_config_str("Notifications", "sender_pw")
@@ -49,7 +50,10 @@ def sendEmailNotification(recipient, alert_name, content):
                 smtp_server = smtplib.SMTP_SSL(sender_host, sender_port)
 
             smtp_server.ehlo()
-            smtp_server.login(sender, sender_pw)
+            if sender_user is not None:
+                smtp_server.login(sender_user, sender_pw)
+            else:
+                smtp_server.login(sender, sender_pw)
         else:
             smtp_server = smtplib.SMTP(sender_host, sender_port)
 

--- a/configs/core.cfg.sample
+++ b/configs/core.cfg.sample
@@ -28,6 +28,9 @@ sender = sender@example.com
 sender_host = smtp.example.com
 sender_port = 1337
 sender_pw = None
+# Only needed when the credentials for email server needs a username instead of an email address
+#sender_user = sender
+sender_user =
 
 # optional for using with authenticated SMTP over SSL
 # sender_pw = securepassword


### PR DESCRIPTION
Dear Ail Team,

I recently found a little problem as example our email server needs an username instead of an email address and therefor Ail cannot send any emails.

I added the support for this matter and tested it, and it worked.

Thank you
Mike