### PR TITLE
Added characters limitation in trackersManagement.html

### DIFF
--- a/var/www/modules/hunter/templates/trackersManagement.html
+++ b/var/www/modules/hunter/templates/trackersManagement.html
@@ -64,8 +64,16 @@
 							{% for dict_uuid in user_term %}
 									<tr>
                     <td>{{dict_uuid['type']}}</td>
-										<td>
-                      <span><a target="_blank" href="{{ url_for('hunter.show_tracker') }}?uuid={{ dict_uuid['uuid'] }}">{{dict_uuid['term']}}</a></span>
+                    <td>
+                      <span>
+                        <a target="_blank" href="{{ url_for('hunter.show_tracker') }}?uuid={{ dict_uuid['uuid'] }}">
+                        {% if dict_uuid['term']|length > 256 %}
+                           {{ dict_uuid['term'][0:256]}}...
+                        {% else %}
+                           {{ dict_uuid['term']}}
+                        {% endif %}
+                        </a>
+                      </span>
                       <div>
                         {% for tag in dict_uuid['tags'] %}
                         <a href="{{ url_for('tags_ui.get_obj_by_tags') }}?object_type=item&ltags={{ tag }}">
@@ -117,8 +125,16 @@
 							{% for dict_uuid in global_term %}
 									<tr>
                     <td>{{dict_uuid['type']}}</td>
-										<td>
-                      <span><a target="_blank" href="{{ url_for('hunter.show_tracker') }}?uuid={{ dict_uuid['uuid'] }}">{{dict_uuid['term']}}</a></span>
+		    <td>
+                      <span>
+                        <a target="_blank" href="{{ url_for('hunter.show_tracker') }}?uuid={{ dict_uuid['uuid'] }}">
+                        {% if dict_uuid['term']|length > 256 %}
+                           {{ dict_uuid['term'][0:256]}}...
+                        {% else %}
+                           {{ dict_uuid['term']}}
+                        {% endif %}
+                        </a>
+                      </span>
                       <div>
                         {% for tag in dict_uuid['tags'] %}
                         <a href="{{ url_for('tags_ui.get_obj_by_tags') }}?object_type=item&ltags={{ tag }}">


### PR DESCRIPTION
Added a characters limitation because I had the problem that one of our regex had more than 4000 chars and the entire table was messed up, this will fix it.

Only the first 256 characters will be showed until you click on the link than you can see the entire regex.

Thank you