### PR TITLE
Fix create case with TheHive

### DIFF
--- a/var/www/modules/PasteSubmit/Flask_PasteSubmit.py
+++ b/var/www/modules/PasteSubmit/Flask_PasteSubmit.py
@@ -439,7 +439,7 @@ def create_hive_case():
     threat_level = int(request.form['threat_level_hive'])
     hive_description = request.form['hive_description']
     hive_case_title = request.form['hive_case_title']
-    path = request.form['paste']
+    path = os.environ['AIL_HOME'] + "/PASTES/"+ request.form['paste']
 
     #verify input
     if (0 <= hive_tlp <= 3) and (1 <= threat_level <= 4):


### PR DESCRIPTION
When creating a case to TheHive from AIL, the attachment was not found and an error was given.
This has been fixed.

![image](https://user-images.githubusercontent.com/10974337/81828479-1ae3cd00-953a-11ea-8516-078953d5b7d0.png)
