### PR TITLE
Added 'wget' as a dependency

### DIFF
--- a/installing_deps.sh
+++ b/installing_deps.sh
@@ -11,6 +11,9 @@ sudo apt-get update
 sudo apt-get install python3-pip virtualenv python3-dev python3-tk libfreetype6-dev \
     screen g++ python-tk unzip libsnappy-dev cmake -qq
 
+#Needed for downloading jemalloc
+sudo apt-get install wget -qq
+
 #optional tor install
 sudo apt-get install tor -qq
 


### PR DESCRIPTION
'wget' is a dependency as without this additional components won't download as part of initial install, one such example is;
```
wget -O /ail-framework/ardb/src/../deps/jemalloc-5.1.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/5.1.0/jemalloc-5.1.0.tar.bz2 && \
```