### PR TITLE
Typo in placeholder "Optionnal" --> "Optional"

### DIFF
--- a/var/www/modules/PasteSubmit/templates/submit_items.html
+++ b/var/www/modules/PasteSubmit/templates/submit_items.html
@@ -112,7 +112,7 @@
 
 									<div class="form-group">
 										<label for="paste_name">Archive Password</label>
-										<input type="password" class="form-control" id="password" name="password" placeholder="Optionnal">
+										<input type="password" class="form-control" id="password" name="password" placeholder="Optional">
 									</div>
 								</div>
 							</div>


### PR DESCRIPTION
Updated placeholder value to correct typo;
`"Optionnal"` --> `"Optional"`